### PR TITLE
Get nginx to listen on port 9090

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -15,6 +15,6 @@ FROM nginx:stable-alpine
 
 COPY --from=builder /usr/src/app/dist /usr/share/nginx/html
 
-EXPOSE 80
+EXPOSE 9090
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,5 @@
 server {
-  listen 80;
+  listen 90;
 
   server_name localhost;
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,5 @@
 server {
-  listen 90;
+  listen 9090;
 
   server_name localhost;
 


### PR DESCRIPTION
port 80 is privileged and blocked in Linux systems (unless we run the container as privileged). Let's listen on port 9090 instead.