### PR TITLE
fix: skip malformed markdown

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -57,6 +57,7 @@ export function Markdown({ children, className = "" }: Props) {
     <ReactMarkdown
       components={{
         code({ className, children, ...props }) {
+          if (!children) return null;
           const detectedLanguage =
             hljs.highlightAuto(children, LANGUAGES_SUBSET_DETECTION).language ??
             "plaintext";


### PR DESCRIPTION
Sometimes Continue and Copilot return malformed markdown for code highlight, we can skip those malformed markdown avoiding ReactMarkdown issue