### PR TITLE
fix: alerts line chart sorting

### DIFF
--- a/src/viz/LineChart.tsx
+++ b/src/viz/LineChart.tsx
@@ -21,24 +21,27 @@ import { AlertConversation } from "@/api/generated/types.gen";
 const aggregateAlertsByDate = (alerts: { timestamp: string }[]) => {
   const dateMap: Record<string, { date: string; alerts: number }> = {};
 
-  alerts.reduce((acc, alert) => {
-    const timestamp = new Date(alert.timestamp);
-    const formattedDate = timestamp.toLocaleDateString("en-US", {
-      month: "short",
-      day: "2-digit",
-    });
+  alerts
+    .sort(
+      (a, b) =>
+        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+    )
+    .reduce((acc, alert) => {
+      const timestamp = new Date(alert.timestamp);
+      const formattedDate = timestamp.toLocaleDateString("en-US", {
+        month: "short",
+        day: "2-digit",
+      });
 
-    if (!acc[formattedDate]) {
-      acc[formattedDate] = { date: formattedDate, alerts: 0 };
-    }
-    (acc[formattedDate] as { alerts: number }).alerts += 1;
+      if (!acc[formattedDate]) {
+        acc[formattedDate] = { date: formattedDate, alerts: 0 };
+      }
+      (acc[formattedDate] as { alerts: number }).alerts += 1;
 
-    return acc;
-  }, dateMap);
+      return acc;
+    }, dateMap);
 
-  return Object.values(dateMap).sort(
-    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
-  );
+  return Object.values(dateMap);
 };
 
 const chartConfig = {


### PR DESCRIPTION
**BEFORE**
<img width="446" alt="Screenshot 2025-01-14 at 19 38 36" src="https://github.com/user-attachments/assets/87ad52dc-175a-403a-b7a0-31447a1865db" />
**AFTER**
<img width="438" alt="Screenshot 2025-01-14 at 19 37 27" src="https://github.com/user-attachments/assets/bcbecd41-b629-4a17-8aaa-a1f68cb6c7c3" />
