### PR TITLE
fix(alerts-table): add clear button to input search

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -9,9 +9,11 @@ import {
   SearchField,
   Table,
   TableBody,
+  FieldGroup,
   TableHeader,
+  SearchFieldClearButton,
+  Badge,
 } from "@stacklok/ui-kit";
-import { Badge } from "@stacklok/ui-kit";
 import { useCallback, useEffect } from "react";
 import { BarChart } from "@/viz/BarChart";
 import { LineChart } from "@/viz/LineChart";
@@ -170,7 +172,15 @@ export function Dashboard() {
             value={search}
             onChange={(value) => handleSearch(value.toLowerCase().trim())}
           >
-            <Input type="search" placeholder="Search..." icon={<Search />} />
+            <FieldGroup>
+              <Input
+                type="search"
+                placeholder="Search..."
+                isBorderless
+                icon={<Search />}
+              />
+              <SearchFieldClearButton />
+            </FieldGroup>
           </SearchField>
         </div>
       </div>


### PR DESCRIPTION
We are missing the clear button in the input search

<img width="455" alt="Screenshot 2025-01-16 at 12 04 41" src="https://github.com/user-attachments/assets/79dc28a0-0fd5-46c2-b258-1e4a73628666" />
