### PR TITLE
chore: remove CVA

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@tanstack/react-query": "^5.64.1",
     "@types/prismjs": "^1.26.5",
     "@types/react-syntax-highlighter": "^15.5.13",
-    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "highlight.js": "^11.11.1",

--- a/src/components/ui/chat/chat-bubble.tsx
+++ b/src/components/ui/chat/chat-bubble.tsx
@@ -1,33 +1,32 @@
 import * as React from "react";
-import { cva, type VariantProps } from "class-variance-authority";
 import MessageLoading from "./message-loading";
 import { Avatar, Button } from "@stacklok/ui-kit";
+import { tv } from "tailwind-variants";
 import { twMerge } from "tailwind-merge";
 
 // ChatBubble
-const chatBubbleVariant = cva(
-  "flex gap-2 max-w-[60%] items-end relative group",
-  {
-    variants: {
-      variant: {
-        received: "self-start",
-        sent: "self-end flex-row-reverse",
-      },
-      layout: {
-        default: "",
-        ai: "max-w-full w-full items-center",
-      },
+const chatBubbleVariant = tv({
+  base: "flex gap-2 max-w-[60%] items-end relative group",
+  variants: {
+    variant: {
+      received: "self-start",
+      sent: "self-end flex-row-reverse",
     },
-    defaultVariants: {
-      variant: "received",
-      layout: "default",
+    layout: {
+      default: "",
+      ai: "max-w-full w-full items-center",
     },
   },
-);
+  defaultVariants: {
+    variant: "received",
+    layout: "default",
+  },
+});
 
-interface ChatBubbleProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof chatBubbleVariant> {}
+interface ChatBubbleProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant: "received" | "sent";
+  layout?: "default" | "ai";
+}
 
 const ChatBubble = React.forwardRef<HTMLDivElement, ChatBubbleProps>(
   ({ className, variant, layout, children, ...props }, ref) => (
@@ -64,10 +63,18 @@ const ChatBubbleAvatar: React.FC<ChatBubbleAvatarProps> = ({
   fallback,
   className,
   ...rest
-}) => <Avatar src={src} name={fallback} className={className} {...rest} />;
+}) => (
+  <Avatar
+    src={src}
+    name={fallback}
+    className={twMerge(className, "rounded-full")}
+    {...rest}
+  />
+);
 
 // ChatBubbleMessage
-const chatBubbleMessageVariants = cva("p-4 bg-gray-100 text-primary", {
+const chatBubbleMessageVariants = tv({
+  base: "p-4 bg-gray-100 text-primary",
   variants: {
     variant: {
       received: "rounded-r-lg rounded-tl-lg",
@@ -84,9 +91,9 @@ const chatBubbleMessageVariants = cva("p-4 bg-gray-100 text-primary", {
   },
 });
 
-interface ChatBubbleMessageProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof chatBubbleMessageVariants> {
+interface ChatBubbleMessageProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant: "received" | "sent";
+  layout?: "default" | "ai";
   isLoading?: boolean;
 }
 

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -2,8 +2,9 @@
 
 import * as React from "react";
 import * as SheetPrimitive from "@radix-ui/react-dialog";
-import { cva, type VariantProps } from "class-variance-authority";
 import { X } from "lucide-react";
+
+import { tv } from "tailwind-variants";
 import { twMerge } from "tailwind-merge";
 
 const Sheet = SheetPrimitive.Root;
@@ -29,28 +30,27 @@ const SheetOverlay = React.forwardRef<
 ));
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
-const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
-  {
-    variants: {
-      side: {
-        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
-        bottom:
-          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
-        right:
-          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
-      },
-    },
-    defaultVariants: {
-      side: "right",
+const sheetVariants = tv({
+  base: "fixed z-50 gap-4 bg-base p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  variants: {
+    side: {
+      top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+      bottom:
+        "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+      left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+      right:
+        "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
     },
   },
-);
+  defaultVariants: {
+    side: "right",
+  },
+});
 
 interface SheetContentProps
-  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content> {
+  side: "top" | "left" | "right" | "bottom";
+}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
-import { VariantProps, cva } from "class-variance-authority";
 import { PanelLeft } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { Tooltip, TooltipTrigger, Button, Skeleton } from "@stacklok/ui-kit";
 import { twMerge } from "tailwind-merge";
+import { tv } from "tailwind-variants";
 
 const SIDEBAR_COOKIE_NAME = "sidebar:state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
@@ -370,27 +370,25 @@ const SidebarMenuItem = React.forwardRef<
 ));
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
-const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none transition-[width,height,padding] hover:bg-gray-25 focus-visible:ring-2 active:bg-gray-25-accent disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-gray-25-accent data-[active=true]:font-medium data-[state=open]:hover:bg-gray-25 group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
-  {
-    variants: {
-      variant: {
-        default: "hover:bg-gray-25",
-        outline:
-          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-gray-25 hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
-      },
-      size: {
-        default: "h-8 text-sm",
-        sm: "h-7 text-sm",
-        lg: "h-12 text-sm group-data-[collapsible=icon]:!p-0",
-      },
+const sidebarMenuButtonVariants = tv({
+  base: "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-brand-600 transition-[width,height,padding] hover:bg-brand-25 hover:text-secondary focus-visible:ring-2 active:bg-gray-25 active:text-secondary disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-gray-25 data-[active=true]:font-medium data-[active=true]:text-secondary data-[state=open]:hover:bg-brand-25 data-[state=open]:hover:text-secondary group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  variants: {
+    variant: {
+      default: "hover:bg-brand-25 hover:text-secondary",
+      outline:
+        "bg-base shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-brand-25 hover:text-secondary hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
     },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
+    size: {
+      default: "h-8 text-sm",
+      sm: "h-7 text-sm",
+      lg: "h-12 text-sm group-data-[collapsible=icon]:!p-0",
     },
   },
-);
+  defaultVariants: {
+    variant: "default",
+    size: "default",
+  },
+});
 
 const SidebarMenuButton = React.forwardRef<
   HTMLButtonElement,
@@ -398,7 +396,10 @@ const SidebarMenuButton = React.forwardRef<
     asChild?: boolean;
     isActive?: boolean;
     tooltip?: string;
-  } & VariantProps<typeof sidebarMenuButtonVariants>
+  } & {
+    variant: "default" | "outline";
+    size: "default" | "sm" | "lg";
+  }
 >(
   (
     {


### PR DESCRIPTION
This just removes the `class-variance-authority` dependency from the project, as it is equivalent to `tailwind-variants`, which is already used in `@stacklok/ui-kit`.