### PR TITLE
test: system prompt editor & workspace route

### DIFF
--- a/src/features/workspace-system-prompt/components/__tests__/system-prompt-editor.test.tsx
+++ b/src/features/workspace-system-prompt/components/__tests__/system-prompt-editor.test.tsx
@@ -1,0 +1,43 @@
+import { render, waitFor } from "@/lib/test-utils";
+import { expect, test } from "vitest";
+import { SystemPromptEditor } from "../system-prompt-editor";
+import userEvent from "@testing-library/user-event";
+import * as POST_MODULE from "../../lib/post-system-prompt";
+
+vi.mock("../../lib/post-system-prompt");
+
+vi.mock("@monaco-editor/react", () => {
+  const FakeEditor = vi.fn((props) => {
+    return (
+      <textarea
+        data-auto={props.wrapperClassName}
+        onChange={(e) => props.onChange(e.target.value)}
+        value={props.value}
+      ></textarea>
+    );
+  });
+  return { default: FakeEditor };
+});
+
+const renderComponent = () => render(<SystemPromptEditor />);
+
+test("can update system prompt", async () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const POST_PROMPT_MOCK = vi.fn(async (_) => Promise.resolve());
+
+  vi.mocked(POST_MODULE).postSystemPrompt = POST_PROMPT_MOCK;
+
+  const { getByRole } = renderComponent();
+
+  const input = getByRole("textbox");
+  expect(input).toBeVisible();
+
+  await userEvent.clear(input);
+  await userEvent.type(input, "foo bar 123");
+  expect(input).toHaveTextContent("foo bar 123");
+
+  await userEvent.click(getByRole("button", { name: /save changes/i }));
+  await waitFor(() => {
+    expect(POST_PROMPT_MOCK).toBeCalledWith("foo bar 123");
+  });
+});

--- a/src/routes/__tests__/route-workspace.test.tsx
+++ b/src/routes/__tests__/route-workspace.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "@/lib/test-utils";
+import { test, expect } from "vitest";
+import { RouteWorkspace } from "../route-workspace";
+
+const renderComponent = () => render(<RouteWorkspace />);
+
+vi.mock("@monaco-editor/react", () => {
+  const FakeEditor = vi.fn((props) => {
+    return (
+      <textarea
+        data-testid="system-prompt-editor"
+        data-auto={props.wrapperClassName}
+        onChange={(e) => props.onChange(e.target.value)}
+        value={props.value}
+      ></textarea>
+    );
+  });
+  return { default: FakeEditor };
+});
+
+test("renders title", () => {
+  const { getByRole } = renderComponent();
+
+  expect(
+    getByRole("heading", { name: "Workspace settings", level: 1 }),
+  ).toBeVisible();
+});
+
+test("renders workspace name input", () => {
+  const { getByRole } = renderComponent();
+
+  expect(getByRole("textbox", { name: "Workspace name" })).toBeVisible();
+});
+
+test("renders system prompt editor", () => {
+  const { getByTestId } = renderComponent();
+
+  expect(getByTestId("system-prompt-editor")).toBeVisible();
+});


### PR DESCRIPTION
Adds test for the system prompt editor & workspace route.
The tests aren't very thorough, and rely heavily on mocking, but give *some* safety.