### PR TITLE
feat: enable toggle workspace, invalidate on workspace update

### DIFF
--- a/src/components/react-query-provider.tsx
+++ b/src/components/react-query-provider.tsx
@@ -1,0 +1,85 @@
+import { V1ListActiveWorkspacesResponse } from "@/api/generated";
+import { v1ListActiveWorkspacesQueryKey } from "@/api/generated/@tanstack/react-query.gen";
+import { toast } from "@stacklok/ui-kit";
+import {
+  QueryCacheNotifyEvent,
+  QueryClient,
+  QueryClientProvider as VendorQueryClientProvider,
+} from "@tanstack/react-query";
+import { ReactNode, useState, useEffect } from "react";
+
+/**
+ * Responsible for determining whether a queryKey attached to a queryCache event
+ * is for the "list active workspaces" query.
+ */
+function isActiveWorkspacesQueryKey(queryKey: unknown): boolean {
+  return (
+    Array.isArray(queryKey) &&
+    queryKey[0]._id === v1ListActiveWorkspacesQueryKey()[0]?._id
+  );
+}
+
+/**
+ * Responsible for extracting the incoming active workspace name from the deeply
+ * nested payload attached to a queryCache event.
+ */
+function getWorkspaceName(event: QueryCacheNotifyEvent): string | null {
+  if ("action" in event === false || "data" in event.action === false)
+    return null;
+  return (
+    (event.action.data as V1ListActiveWorkspacesResponse | undefined | null)
+      ?.workspaces[0]?.name ?? null
+  );
+}
+
+export function QueryClientProvider({ children }: { children: ReactNode }) {
+  const [activeWorkspaceName, setActiveWorkspaceName] = useState<string | null>(
+    null,
+  );
+
+  const [queryClient] = useState(() => new QueryClient());
+
+  useEffect(() => {
+    const queryCache = queryClient.getQueryCache();
+    const unsubscribe = queryCache.subscribe((event) => {
+      if (
+        event.type === "updated" &&
+        event.action.type === "success" &&
+        isActiveWorkspacesQueryKey(event.query.options.queryKey)
+      ) {
+        const newWorkspaceName: string | null = getWorkspaceName(event);
+        if (
+          newWorkspaceName === activeWorkspaceName ||
+          newWorkspaceName === null
+        )
+          return;
+
+        setActiveWorkspaceName(newWorkspaceName);
+        toast.info(
+          <span className="block whitespace-nowrap">
+            Activated workspace:{" "}
+            <span className="font-semibold">"{newWorkspaceName}"</span>
+          </span>,
+        );
+
+        void queryClient.invalidateQueries({
+          refetchType: "all",
+          // Avoid a continuous loop
+          predicate(query) {
+            return !isActiveWorkspacesQueryKey(query.queryKey);
+          },
+        });
+      }
+    });
+
+    return () => {
+      return unsubscribe();
+    };
+  }, [activeWorkspaceName, queryClient]);
+
+  return (
+    <VendorQueryClientProvider client={queryClient}>
+      {children}
+    </VendorQueryClientProvider>
+  );
+}

--- a/src/features/workspace/components/workspaces-selection.tsx
+++ b/src/features/workspace/components/workspaces-selection.tsx
@@ -15,6 +15,7 @@ import { ChevronDown, Search, Settings } from "lucide-react";
 import { useState } from "react";
 import { useActiveWorkspaces } from "../hooks/use-active-workspaces";
 import { useActivateWorkspace } from "../hooks/use-activate-workspace";
+import clsx from "clsx";
 
 export function WorkspacesSelection() {
   const queryClient = useQueryClient();
@@ -60,23 +61,30 @@ export function WorkspacesSelection() {
           </div>
 
           <ListBox
-            className="pb-2 pt-3"
             aria-label="Workspaces"
             items={filteredWorkspaces}
             selectedKeys={activeWorkspaceName ? [activeWorkspaceName] : []}
-            selectionMode="single"
-            onSelectionChange={(v) => {
-              if (v === "all") return; // Not possible with `selectionMode="single"`
-              const [key] = v.keys();
-              if (!key) return;
-              handleWorkspaceClick(key?.toString());
+            onAction={(v) => {
+              handleWorkspaceClick(v?.toString());
             }}
+            className="py-2 pt-3"
             renderEmptyState={() => (
               <p className="text-center">No workspaces found</p>
             )}
           >
             {(item) => (
-              <ListBoxItem id={item.name} key={item.name}>
+              <ListBoxItem
+                id={item.name}
+                key={item.name}
+                data-is-selected={item.name === activeWorkspaceName}
+                className={clsx(
+                  "cursor-pointer py-2 m-1 text-base hover:bg-gray-300",
+                  {
+                    "!bg-gray-900 hover:bg-gray-900 !text-gray-25 hover:!text-gray-25":
+                      item.is_active,
+                  },
+                )}
+              >
                 {item.name}
               </ListBoxItem>
             )}

--- a/src/features/workspace/hooks/use-activate-workspace.ts
+++ b/src/features/workspace/hooks/use-activate-workspace.ts
@@ -1,0 +1,8 @@
+import { v1ActivateWorkspaceMutation } from "@/api/generated/@tanstack/react-query.gen";
+import { useMutation } from "@tanstack/react-query";
+
+export function useActivateWorkspace() {
+  return useMutation({
+    ...v1ActivateWorkspaceMutation(),
+  });
+}

--- a/src/features/workspace/hooks/use-active-workspaces.ts
+++ b/src/features/workspace/hooks/use-active-workspaces.ts
@@ -1,0 +1,14 @@
+import { v1ListActiveWorkspacesOptions } from "@/api/generated/@tanstack/react-query.gen";
+import { useQuery } from "@tanstack/react-query";
+
+export function useActiveWorkspaces() {
+  return useQuery({
+    ...v1ListActiveWorkspacesOptions(),
+    refetchInterval: 5_000,
+    refetchIntervalInBackground: true,
+    refetchOnMount: true,
+    refetchOnReconnect: true,
+    refetchOnWindowFocus: true,
+    retry: false,
+  });
+}

--- a/src/features/workspace/hooks/use-list-workspaces.ts
+++ b/src/features/workspace/hooks/use-list-workspaces.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { v1ListWorkspacesOptions } from "@/api/generated/@tanstack/react-query.gen";
+
+export const useListWorkspaces = () => {
+  return useQuery({
+    ...v1ListWorkspacesOptions(),
+    refetchInterval: 5_000,
+    refetchIntervalInBackground: true,
+    refetchOnMount: true,
+    refetchOnReconnect: true,
+    refetchOnWindowFocus: true,
+    retry: false,
+  });
+};

--- a/src/hooks/useWorkspacesData.ts
+++ b/src/hooks/useWorkspacesData.ts
@@ -1,8 +1,0 @@
-import { useQuery } from "@tanstack/react-query";
-import { v1ListWorkspacesOptions } from "@/api/generated/@tanstack/react-query.gen";
-
-export const useWorkspacesData = () => {
-  return useQuery({
-    ...v1ListWorkspacesOptions(),
-  });
-};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,11 +5,11 @@ import "@stacklok/ui-kit/style";
 import App from "./App.tsx";
 import { BrowserRouter } from "react-router-dom";
 import { SidebarProvider } from "./components/ui/sidebar.tsx";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import ErrorBoundary from "./components/ErrorBoundary.tsx";
 import { Error } from "./components/Error.tsx";
-import { DarkModeProvider } from "@stacklok/ui-kit";
+import { DarkModeProvider, Toaster } from "@stacklok/ui-kit";
 import { client } from "./api/generated/index.ts";
+import { QueryClientProvider } from "./components/react-query-provider.tsx";
 
 // Initialize the API client
 client.setConfig({
@@ -22,7 +22,8 @@ createRoot(document.getElementById("root")!).render(
       <DarkModeProvider>
         <SidebarProvider>
           <ErrorBoundary fallback={<Error />}>
-            <QueryClientProvider client={new QueryClient()}>
+            <QueryClientProvider>
+              <Toaster />
               <App />
             </QueryClientProvider>
           </ErrorBoundary>

--- a/src/mocks/msw/handlers.ts
+++ b/src/mocks/msw/handlers.ts
@@ -12,16 +12,25 @@ export const handlers = [
       error: null,
     }),
   ),
-  http.get("*/dashboard/version", () =>
+  http.get("*/api/v1/dashboard/version", () =>
     HttpResponse.json({ status: "healthy" }),
   ),
-  http.get("*/dashboard/messages", () => {
+  http.get("*/api/v1/workspaces/active", () =>
+    HttpResponse.json([
+      {
+        name: "my-awesome-workspace",
+        is_active: true,
+        last_updated: new Date(Date.now()).toISOString(),
+      },
+    ]),
+  ),
+  http.get("*/api/v1/dashboard/messages", () => {
     return HttpResponse.json(mockedPrompts);
   }),
-  http.get("*/dashboard/alerts", () => {
+  http.get("*/api/v1/dashboard/alerts", () => {
     return HttpResponse.json(mockedAlerts);
   }),
-  http.get("*/workspaces", () => {
+  http.get("*/api/v1/workspaces", () => {
     return HttpResponse.json(mockedWorkspaces);
   }),
 ];

--- a/src/routes/route-workspaces.tsx
+++ b/src/routes/route-workspaces.tsx
@@ -1,4 +1,4 @@
-import { useWorkspacesData } from "@/hooks/useWorkspacesData";
+import { useListWorkspaces } from "@/features/workspace/hooks/use-list-workspaces";
 import {
   Cell,
   Column,
@@ -12,7 +12,7 @@ import {
 import { Settings } from "lucide-react";
 
 export function RouteWorkspaces() {
-  const result = useWorkspacesData();
+  const result = useListWorkspaces();
   const workspaces = result.data?.workspaces ?? [];
 
   return (


### PR DESCRIPTION
- adds a "mutation" hook to the workspace selection component, which allows toggling workspaces
- wraps the app a custom react-query QueryClientProvider, which subscribes to events in the query cache to enable the following
  - when the cached value for GET /api/v1/workspaces/active is updated, the provider will compare the active workspace ID — if it is new, it will invalidate the query cache and post a toast notification with the newly activated workspace name
- a `useActiveWorkspaces` hook is implemented, which polls the server on an interval, as well as every time the window is focused, or it reconnects — this should ensure that it is always up to date

https://github.com/user-attachments/assets/2965faac-1f4a-4477-a3d0-c9585f131e91

Closes #126
Closes #124 

