### PR TITLE
fix: workspace ui nits

### DIFF
--- a/src/features/workspace-system-prompt/components/system-prompt-editor.tsx
+++ b/src/features/workspace-system-prompt/components/system-prompt-editor.tsx
@@ -17,6 +17,7 @@ import {
 } from "react";
 import { usePostSystemPrompt } from "../hooks/use-post-system-prompt";
 import { Check } from "lucide-react";
+import { twMerge } from "tailwind-merge";
 
 type DarkModeContextValue = {
   preference: "dark" | "light" | null;
@@ -63,7 +64,7 @@ export function SystemPromptEditor({ className }: { className?: string }) {
   const { saved, setSaved } = useSavedStatus();
 
   return (
-    <Card className={className}>
+    <Card className={twMerge(className, "shrink-0")}>
       <CardBody>
         <Text className="text-primary">Custom prompt</Text>
         <Text className="text-secondary mb-4">
@@ -86,7 +87,9 @@ export function SystemPromptEditor({ className }: { className?: string }) {
         </div>
       </CardBody>
       <CardFooter className="justify-end gap-2">
-        <LinkButton variant="secondary">Cancel</LinkButton>
+        <LinkButton href="/workspaces" variant="secondary">
+          Cancel
+        </LinkButton>
         <Button
           isPending={isPending}
           isDisabled={saved}

--- a/src/features/workspace/components/workspace-name.tsx
+++ b/src/features/workspace/components/workspace-name.tsx
@@ -1,8 +1,9 @@
 import { Card, CardBody, Input, Label, TextField } from "@stacklok/ui-kit";
+import { twMerge } from "tailwind-merge";
 
 export function WorkspaceName({ className }: { className?: string }) {
   return (
-    <Card className={className}>
+    <Card className={twMerge(className, "shrink-0")}>
       <CardBody>
         <TextField value="my-awesome-workspace" isReadOnly>
           <Label>Workspace name</Label>


### PR DESCRIPTION
- adds a missing href to leave the "workspace settings" page
- adds `shrink-0` to cards on "workspace settings" page to prevent them from clipping their contents