### PR TITLE
fix: buttons in workspace page

### DIFF
--- a/src/features/workspace-system-prompt/components/__tests__/system-prompt-editor.test.tsx
+++ b/src/features/workspace-system-prompt/components/__tests__/system-prompt-editor.test.tsx
@@ -43,7 +43,7 @@ test("can update system prompt", async () => {
   await userEvent.type(input, "new prompt from test");
   expect(input).toHaveTextContent("new prompt from test");
 
-  await userEvent.click(getByRole("button", { name: /save changes/i }));
+  await userEvent.click(getByRole("button", { name: /Save/i }));
 
   server.use(
     http.get("*/api/v1/workspaces/:name/system-prompt", () => {

--- a/src/features/workspace-system-prompt/components/system-prompt-editor.tsx
+++ b/src/features/workspace-system-prompt/components/system-prompt-editor.tsx
@@ -5,7 +5,6 @@ import {
   CardBody,
   CardFooter,
   DarkModeContext,
-  LinkButton,
   Loader,
   Text,
 } from "@stacklok/ui-kit";
@@ -207,9 +206,6 @@ export function SystemPromptEditor({
         </div>
       </CardBody>
       <CardFooter className="justify-end gap-2">
-        <LinkButton href="/workspaces" variant="secondary">
-          Cancel
-        </LinkButton>
         <Button
           isPending={isMutationPending}
           isDisabled={Boolean(isGetPromptPending ?? saved)}
@@ -220,7 +216,7 @@ export function SystemPromptEditor({
               <span>Saved</span> <Check />
             </>
           ) : (
-            "Save changes"
+            "Save"
           )}
         </Button>
       </CardFooter>

--- a/src/features/workspace/components/archive-workspace.tsx
+++ b/src/features/workspace/components/archive-workspace.tsx
@@ -13,22 +13,24 @@ export function ArchiveWorkspace({
 
   return (
     <Card className={twMerge(className, "shrink-0")}>
-      <CardBody>
-        <Text className="text-primary">Archive Workspace</Text>
-        <div className="flex justify-between items-center">
+      <CardBody className="flex justify-between items-center">
+        <div>
+          <Text className="text-primary">Archive Workspace</Text>
           <Text className="flex items-center text-secondary mb-0">
             Archiving this workspace removes it from the main workspaces list,
             though it can be restored if needed.
           </Text>
-          <Button
-            isPending={isPending}
-            onPress={() => {
-              mutate({ path: { workspace_name: workspaceName } });
-            }}
-          >
-            Archive
-          </Button>
         </div>
+
+        <Button
+          isDestructive
+          isPending={isPending}
+          onPress={() => {
+            mutate({ path: { workspace_name: workspaceName } });
+          }}
+        >
+          Archive
+        </Button>
       </CardBody>
     </Card>
   );


### PR DESCRIPTION
- makes the "archive" button "destructive"
- removes the "cancel" button from update system prompt
- renames the "save" button for update system prompt