### PR TITLE
feat: use client-side routing for ui-kit

### DIFF
--- a/src/Page.tsx
+++ b/src/Page.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes, useHref, useNavigate } from "react-router-dom";
 
 import { RouteWorkspace } from "./routes/route-workspace";
 import { RouteWorkspaces } from "./routes/route-workspaces";
@@ -8,21 +8,26 @@ import { RouteChat } from "./routes/route-chat";
 import { RouteDashboard } from "./routes/route-dashboard";
 import { RouteCertificateSecurity } from "./routes/route-certificate-security";
 import { RouteWorkspaceCreation } from "./routes/route-workspace-creation";
+import { RouterProvider } from "@stacklok/ui-kit";
 
 export default function Page() {
+  const navigate = useNavigate();
+
   return (
-    <Routes>
-      <Route path="/" element={<RouteDashboard />} />
-      <Route path="/prompt/:id" element={<RouteChat />} />
-      <Route path="/help/:section" element={<RouteHelp />} />
-      <Route path="/certificates" element={<RouteCertificates />} />
-      <Route path="/workspace/:name" element={<RouteWorkspace />} />
-      <Route path="/workspaces" element={<RouteWorkspaces />} />
-      <Route path="/workspace/create" element={<RouteWorkspaceCreation />} />
-      <Route
-        path="/certificates/security"
-        element={<RouteCertificateSecurity />}
-      />
-    </Routes>
+    <RouterProvider navigate={navigate} useHref={useHref}>
+      <Routes>
+        <Route path="/" element={<RouteDashboard />} />
+        <Route path="/prompt/:id" element={<RouteChat />} />
+        <Route path="/help/:section" element={<RouteHelp />} />
+        <Route path="/certificates" element={<RouteCertificates />} />
+        <Route path="/workspace/:name" element={<RouteWorkspace />} />
+        <Route path="/workspaces" element={<RouteWorkspaces />} />
+        <Route path="/workspace/create" element={<RouteWorkspaceCreation />} />
+        <Route
+          path="/certificates/security"
+          element={<RouteCertificateSecurity />}
+        />
+      </Routes>
+    </RouterProvider>
   );
 }


### PR DESCRIPTION
fixes https://github.com/stacklok/codegate-ui/issues/162

Summary:

- the problem was simply caused by not using client-side routing in most cases - which meant that most navigation lead to a full page reload, which effectively invalidates react-router's cache, since the cache is only stored in memory
- This was solved earlier when I added the client-side routing configuration for ui-kit components. But this fix was later removed because it broke external links.
- I discovered that if I simply do not provide useHref to the router provider, external links work, and all client side navigation seems to work as well


Demo: 