### PR TITLE
fix: fix client side navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,24 +4,29 @@ import { usePromptsData } from "./hooks/usePromptsData";
 import { Sidebar } from "./components/Sidebar";
 import { useSse } from "./hooks/useSse";
 import Page from "./Page";
+import { useNavigate } from "react-router-dom";
+import { RouterProvider } from "@stacklok/ui-kit";
 
 function App() {
   const { data: prompts, isLoading } = usePromptsData();
+  const navigate = useNavigate();
   useSse();
 
   return (
-    <div className="flex w-screen h-screen">
-      <Sidebar loading={isLoading}>
-        <PromptList prompts={prompts ?? []} />
-      </Sidebar>
-      <div className="flex-1 flex flex-col overflow-hidden">
-        <Header />
+    <RouterProvider navigate={navigate}>
+      <div className="flex w-screen h-screen">
+        <Sidebar loading={isLoading}>
+          <PromptList prompts={prompts ?? []} />
+        </Sidebar>
+        <div className="flex-1 flex flex-col overflow-hidden">
+          <Header />
 
-        <div className="flex-1 overflow-y-auto p-6 flex flex-col gap-3">
-          <Page />
+          <div className="flex-1 overflow-y-auto p-6 flex flex-col gap-3">
+            <Page />
+          </div>
         </div>
       </div>
-    </div>
+    </RouterProvider>
   );
 }
 


### PR DESCRIPTION
fixes https://github.com/stacklok/codegate-ui/issues/162

Summary:

- the problem was simply caused by not using client-side routing in most cases - which meant that most navigation lead to a full page reload, which effectively invalidates react-router's cache, since the cache is only stored in memory
- This was solved earlier when I added the client-side routing configuration for ui-kit components. But this fix was later removed because it broke external links.
- I discovered that if I simply do not provide useHref to the router provider, external links work, and all client side navigation seems to work as well


Demo: 