### PR TITLE
feat: useKbdShortcuts hook & example implementation

### DIFF
--- a/src/hooks/use-kbd-shortcuts.ts
+++ b/src/hooks/use-kbd-shortcuts.ts
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 
 export function useKbdShortcuts(map: [string, () => void][]) {
   return useEffect(() => {
-    // Attach a listener to the document to listen for the "/" key
     const documentListener = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
       if (

--- a/src/hooks/use-kbd-shortcuts.ts
+++ b/src/hooks/use-kbd-shortcuts.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+
+export function useKbdShortcuts(map: [string, () => void][]) {
+  return useEffect(() => {
+    // Attach a listener to the document to listen for the "/" key
+    const documentListener = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      for (const [key, callback] of map) {
+        if (e.key.toLowerCase() === key.toLowerCase()) {
+          e.preventDefault();
+          e.stopPropagation();
+          callback();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", documentListener);
+
+    return () => {
+      document.removeEventListener("keydown", documentListener);
+    };
+  }, [map]);
+}

--- a/src/lib/hrefs.ts
+++ b/src/lib/hrefs.ts
@@ -1,0 +1,5 @@
+export const hrefs = {
+  workspaces: {
+    create: "/workspace/create",
+  },
+};

--- a/src/routes/route-workspaces.tsx
+++ b/src/routes/route-workspaces.tsx
@@ -19,6 +19,9 @@ import { useArchivedWorkspaces } from "@/features/workspace/hooks/use-archived-w
 import { Workspace } from "@/api/generated";
 import SvgFlipBackward from "@/components/icons/FlipBackward";
 import { useRestoreWorkspaceButton } from "@/features/workspace/hooks/use-restore-workspace-button";
+import { useKbdShortcuts } from "@/hooks/use-kbd-shortcuts";
+import { useNavigate } from "react-router-dom";
+import { hrefs } from "@/lib/hrefs";
 
 function CellName({
   name,
@@ -89,6 +92,10 @@ export function RouteWorkspaces() {
     })) ?? []),
   ];
 
+  const navigate = useNavigate();
+
+  useKbdShortcuts([["c", () => navigate(hrefs.workspaces.create)]]);
+
   return (
     <>
       <Breadcrumbs>
@@ -97,7 +104,7 @@ export function RouteWorkspaces() {
       </Breadcrumbs>
 
       <WorkspaceHeading title="Manage Workspaces">
-        <LinkButton href="/workspace/create" className="w-fit gap-2">
+        <LinkButton href={hrefs.workspaces.create} className="w-fit gap-2">
           <SquarePlus /> Create Workspace
         </LinkButton>
       </WorkspaceHeading>


### PR DESCRIPTION
Following the adage of "build the things you want to see in the product"  — I added a hook that can be used to wire up keyboard shortcuts.

While working on "hard delete" for workspaces, I found myself wanting "C" to create a **lot**. I think overtime we can instrument the entire app for productivity like this.