### PR TITLE
chore: enforce use of useToastMutation

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ import globals from "globals";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
-import tailwindPlugin from 'eslint-plugin-tailwindcss'
+import tailwindPlugin from "eslint-plugin-tailwindcss";
 
 export default tseslint.config(
   { ignores: ["dist"] },
@@ -56,6 +56,18 @@ export default tseslint.config(
           ],
         },
       ],
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              importNames: ["useMutation"],
+              message: "Use the custom `useToastMutation` instead",
+              name: "@tanstack/react-query",
+            },
+          ],
+        },
+      ],
     },
-  }
+  },
 );

--- a/src/hooks/use-toast-mutation.ts
+++ b/src/hooks/use-toast-mutation.ts
@@ -1,6 +1,7 @@
 import { toast } from "@stacklok/ui-kit";
 import {
   DefaultError,
+  // eslint-disable-next-line no-restricted-imports
   useMutation,
   UseMutationOptions,
 } from "@tanstack/react-query";


### PR DESCRIPTION
Uses the `no-restricted-imports` rule to disallow using `useMutation` from `@tanstack/react-query` and standardises use of the `useToastMutation` wrapper (better UX)

Closes #182 