### PR TITLE
fix(alert detected type): don't default to leaked secret

### DIFF
--- a/src/components/AlertsTable.tsx
+++ b/src/components/AlertsTable.tsx
@@ -176,10 +176,10 @@ export function AlertsTable() {
         <Table data-testid="alerts-table" aria-label="Alerts table">
           <TableHeader>
             <Row>
+              <Column className="w-[150px]">Time</Column>
               <Column isRowHeader className="w-[150px]">
-                Time
+                Type
               </Column>
-              <Column className="w-[150px]">Type</Column>
               <Column>Event</Column>
               <Column width={325}>Issue Detected</Column>
             </Row>

--- a/src/features/alerts/lib/__tests__/is-alert-malicious.test.ts
+++ b/src/features/alerts/lib/__tests__/is-alert-malicious.test.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "vitest";
+import { isAlertMalicious } from "../is-malicious";
+import { ALERT_MALICIOUS } from "../../mocks/alert-malicious.mock";
+import { ALERT_SECRET } from "../../mocks/alert-secret.mock";
+
+test("matches malicious alert", () => {
+  expect(isAlertMalicious(ALERT_MALICIOUS)).toBe(true);
+});
+
+test("doesn't match secret", () => {
+  expect(isAlertMalicious(ALERT_SECRET)).toBe(false);
+});

--- a/src/features/alerts/lib/__tests__/is-alert-secret.test.ts
+++ b/src/features/alerts/lib/__tests__/is-alert-secret.test.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "vitest";
+import { ALERT_MALICIOUS } from "../../mocks/alert-malicious.mock";
+import { ALERT_SECRET } from "../../mocks/alert-secret.mock";
+import { isAlertSecret } from "../is-alert-secret";
+
+test("matches secret alert", () => {
+  expect(isAlertSecret(ALERT_SECRET)).toBe(true);
+});
+
+test("doesn't match secret", () => {
+  expect(isAlertSecret(ALERT_MALICIOUS)).toBe(false);
+});

--- a/src/features/alerts/lib/is-alert-secret.ts
+++ b/src/features/alerts/lib/is-alert-secret.ts
@@ -1,0 +1,8 @@
+import { AlertConversation } from "@/api/generated";
+
+export function isAlertSecret({
+  trigger_type,
+  trigger_category,
+}: AlertConversation) {
+  return trigger_category === "critical" && trigger_type === "codegate-secrets";
+}

--- a/src/features/alerts/lib/is-malicious.ts
+++ b/src/features/alerts/lib/is-malicious.ts
@@ -1,0 +1,14 @@
+import { AlertConversation } from "@/api/generated";
+
+export function isAlertMalicious({
+  trigger_string,
+  trigger_category,
+}: AlertConversation) {
+  return (
+    trigger_category === "critical" &&
+    trigger_string !== null &&
+    typeof trigger_string === "object" &&
+    "status" in trigger_string &&
+    trigger_string.status === "malicious"
+  );
+}

--- a/src/features/alerts/mocks/alert-malicious.mock.ts
+++ b/src/features/alerts/mocks/alert-malicious.mock.ts
@@ -1,0 +1,37 @@
+import { AlertConversation, QuestionType } from "@/api/generated";
+
+export const ALERT_MALICIOUS = {
+  conversation: {
+    question_answers: [
+      {
+        question: {
+          message:
+            "Context: invokehttp is a Python package available on PyPI ecosystem.  However, this package is found to be malicious and must not be used. For additional information refer to https://www.insight.stacklok.com/report/pypi/invokehttp - Package offers this functionality: Python HTTP for Humans.\n \n\n Query: Is invokehttp a malicious package?",
+          timestamp: "2025-01-14T16:29:49.602403Z",
+          message_id: "bf92bf3c-fcec-4064-ad02-c792026c3555",
+        },
+        answer: {
+          message:
+            "**Warning:** CodeGate detected one or more malicious, deprecated or archived packages.\n- Pkg 1: [https://www.insight.stacklok.com/report/pypi/invokehttp](https://www.insight.stacklok.com/report/pypi/invokehttp)",
+          timestamp: "2025-01-14T16:29:50.213490Z",
+          message_id: "7e260699-906e-43dc-a43e-8f288389bd9d",
+        },
+      },
+    ],
+    provider: "copilot",
+    type: QuestionType.CHAT,
+    chat_id: "bf92bf3c-fcec-4064-ad02-c792026c3555",
+    conversation_timestamp: "2025-01-14T16:29:49.602403Z",
+  },
+  alert_id: "bf92bf3c-fcec-4064-ad02-c792026c3555",
+  code_snippet: null,
+  trigger_string: {
+    name: "invokehttp",
+    type: "pypi",
+    status: "malicious",
+    description: "Python HTTP for Humans.",
+  },
+  trigger_type: "codegate-context-retriever",
+  trigger_category: "critical",
+  timestamp: "2025-01-14T16:29:49.602403Z",
+} satisfies AlertConversation;

--- a/src/features/alerts/mocks/alert-secret.mock.ts
+++ b/src/features/alerts/mocks/alert-secret.mock.ts
@@ -1,0 +1,32 @@
+import { AlertConversation, QuestionType } from "@/api/generated";
+
+export const ALERT_SECRET = {
+  conversation: {
+    question_answers: [
+      {
+        question: {
+          message: "Analyse this file please",
+          timestamp: "2025-01-13T17:15:06.942856Z",
+          message_id: "11ab8b11-0338-4fdb-b329-2184d3e71a14",
+        },
+        answer: {
+          message:
+            'The `.env` file you provided contains environment variable definitions that are typically used in applications to configure settings without hardcoding them into the source code. Here\'s a breakdown of each line in the file:\n\n1. **`AUTH_KEYCLOAK_ID="minder-frontend"`**:\n   - This variable likely represents the identifier for the Keycloak client used for authentication. It specifies which client (in this case, `minder-frontend`) is being used to authenticate users.\n\n2. **`AUTH_KEYCLOAK_ISSUER="https://auth.sandbox.stacklok.dev/realms/stacklok"`**:\n   - This variable specifies the URL of the Keycloak issuer. It points to the Keycloak server\'s realm where the authentication takes place. This URL is used to validate tokens and manage user sessions.\n\n3. **`AUTH_SECRET="minder-ui-secret"`**:\n   - This variable holds a secret key used for signing or encrypting tokens. It is crucial for maintaining the security of the authentication process. This secret should be kept confidential and not exposed in public repositories.\n\n4. **`NEXT_PUBLIC_API_URL="https://api.sandbox.stacklok.dev"`**:\n   - This variable defines the base URL for the API that the frontend application will interact with. The `NEXT_PUBLIC_` prefix indicates that this variable is accessible in the client-side code, which is typical in Next.js applications.\n\n5. **`NEXT_PUBLIC_BASE_URL="https://cloud.stacklok.com"`**:\n   - Similar to the previous variable, this defines the base URL for the application. It may be used for routing or linking to different parts of the application.\n\n6. **`NEXT_PUBLIC_INSIGHT_API_URL=https://trusty.stacklok.dev`**:\n   - This variable specifies another API endpoint that the application may use. It is also prefixed with `NEXT_PUBLIC_`, indicating that it is accessible in the client-side code. Note that this variable does not have quotes around the URL, which is acceptable in `.env` files but may lead to inconsistencies if other variables are quoted.\n\n### Summary:\n- The `.env` file is used to store configuration settings for the application, particularly related to authentication and API endpoints.\n- The use of `NEXT_PUBLIC_` indicates that these variables are intended to be exposed to the client-side code in a Next.js application.\n- It is important to ensure that sensitive information, such as `AUTH_SECRET`, is kept secure and not exposed in public repositories or client-side code.\n- Consistency in quoting values is recommended for clarity and to avoid potential issues.',
+          timestamp: "2025-01-13T17:15:08.537530Z",
+          message_id: "f1a6201f-0d7f-4c93-bb84-525f2a2d0d3b",
+        },
+      },
+    ],
+    provider: "copilot",
+    type: QuestionType.CHAT,
+    chat_id: "11ab8b11-0338-4fdb-b329-2184d3e71a14",
+    conversation_timestamp: "2025-01-13T17:15:06.942856Z",
+  },
+  alert_id: "11ab8b11-0338-4fdb-b329-2184d3e71a14",
+  code_snippet: null,
+  trigger_string:
+    "Amazon - Secret Access Key:\n    steps:\n      - name: Checkout Repository\n        uses: REDACTED<$BeldxVmNty++LTH/0/z3/S2sJZVvZC16b/S4On/cKkTuT6p7ygAa+NQkVQ/Yrf8pIV4Aat0L7GaEXuOWN0ITKrq7b0+YfBhNaunpOX0n5ACs+drUjmuj4Vi9uNkbxlNl> # v4\n\n      - name: Setup\n        uses: ./.github/actions/setup",
+  trigger_type: "codegate-secrets",
+  trigger_category: "critical",
+  timestamp: "2025-01-13T17:15:06.942856Z",
+} satisfies AlertConversation;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,6 @@
 import { AlertConversation, Conversation } from "@/api/generated/types.gen";
+import { isAlertSecret } from "@/features/alerts/lib/is-alert-secret";
+import { isAlertMalicious } from "@/features/alerts/lib/is-malicious";
 import { MaliciousPkgType, TriggerType } from "@/types";
 import { format, isToday, isYesterday } from "date-fns";
 
@@ -178,12 +180,9 @@ export function getMaliciousPackage(
 
 export function getIssueDetectedType(
   alert: AlertConversation,
-): "malicious_package" | "leaked_secret" {
-  const maliciousPackage = getMaliciousPackage(alert.trigger_string);
+): "malicious_package" | "leaked_secret" | null {
+  if (isAlertMalicious(alert)) return "malicious_package";
+  if (isAlertSecret(alert)) return "leaked_secret";
 
-  if (maliciousPackage !== null && typeof maliciousPackage === "object") {
-    return "malicious_package";
-  }
-
-  return "leaked_secret";
+  return null;
 }


### PR DESCRIPTION
- fixes a minor nit in `getIssueDetectedType` where we were defaulting to "leaked" secret if an alert was not malicious
- fixes a failing test in `AlertsTable`