### PR TITLE
fix(alerts): memoize selecting alerts

### DIFF
--- a/src/features/alerts/hooks/use-query-get-workspace-alerts-malicious-pkg.ts
+++ b/src/features/alerts/hooks/use-query-get-workspace-alerts-malicious-pkg.ts
@@ -1,9 +1,19 @@
+import {
+  AlertConversation,
+  V1GetWorkspaceAlertsResponse,
+} from "@/api/generated";
 import { filterAlertsCritical } from "../lib/filter-alerts-critical";
 import { isAlertMalicious } from "../lib/is-alert-malicious";
 import { useQueryGetWorkspaceAlerts } from "./use-query-get-workspace-alerts";
 
+// NOTE: This needs to be a stable function reference to enable memo-isation of
+// the select operation on each React re-render.
+function select(data: V1GetWorkspaceAlertsResponse): AlertConversation[] {
+  return filterAlertsCritical(data).filter(isAlertMalicious);
+}
+
 export function useQueryGetWorkspaceAlertsMaliciousPkg() {
   return useQueryGetWorkspaceAlerts({
-    select: (data) => filterAlertsCritical(data).filter(isAlertMalicious),
+    select,
   });
 }

--- a/src/features/alerts/hooks/use-query-get-workspace-alerts-secrets.ts
+++ b/src/features/alerts/hooks/use-query-get-workspace-alerts-secrets.ts
@@ -1,9 +1,19 @@
+import {
+  V1GetWorkspaceAlertsResponse,
+  AlertConversation,
+} from "@/api/generated";
 import { filterAlertsCritical } from "../lib/filter-alerts-critical";
 import { isAlertSecret } from "../lib/is-alert-secret";
 import { useQueryGetWorkspaceAlerts } from "./use-query-get-workspace-alerts";
 
+// NOTE: This needs to be a stable function reference to enable memo-isation of
+// the select operation on each React re-render.
+function select(data: V1GetWorkspaceAlertsResponse): AlertConversation[] {
+  return filterAlertsCritical(data).filter(isAlertSecret);
+}
+
 export function useQueryGetWorkspaceAlertSecrets() {
   return useQueryGetWorkspaceAlerts({
-    select: (data) => filterAlertsCritical(data).filter(isAlertSecret),
+    select,
   });
 }

--- a/src/features/workspace/hooks/use-active-workspace-name.ts
+++ b/src/features/workspace/hooks/use-active-workspace-name.ts
@@ -1,7 +1,14 @@
+import { ListActiveWorkspacesResponse } from "@/api/generated";
 import { useActiveWorkspaces } from "./use-active-workspaces";
+
+// NOTE: This needs to be a stable function reference to enable memo-isation of
+// the select operation on each React re-render.
+function select(data: ListActiveWorkspacesResponse | undefined): string | null {
+  return data?.workspaces?.[0]?.name ?? null;
+}
 
 export function useActiveWorkspaceName() {
   return useActiveWorkspaces({
-    select: (d) => d?.workspaces?.[0]?.name ?? null,
+    select,
   });
 }

--- a/src/hooks/useAlertsData.ts
+++ b/src/hooks/useAlertsData.ts
@@ -52,6 +52,8 @@ export const useFilteredAlerts = () => {
   const { isMaliciousFilterActive, search } = useAlertSearch();
 
   return useAlertsData({
+    // NOTE: Inlined select will run on every render, we'll remove this over
+    // time though - AMG
     select: (
       data: Exclude<ReturnType<typeof useAlertsData>["data"], undefined>,
     ) => {

--- a/src/hooks/usePromptsData.ts
+++ b/src/hooks/usePromptsData.ts
@@ -7,13 +7,13 @@ import {
 import { v1GetWorkspaceMessagesOptions } from "@/api/generated/@tanstack/react-query.gen";
 import { useActiveWorkspaceName } from "@/features/workspace/hooks/use-active-workspace-name";
 
-const selectConversations = (
-  data: V1GetWorkspaceMessagesResponse,
-): Conversation[] => {
+// NOTE: This needs to be a stable function reference to enable memo-isation of
+// the select operation on each React re-render.
+function select(data: V1GetWorkspaceMessagesResponse): Conversation[] {
   return data.filter((prompt) =>
     prompt.question_answers?.every((item) => item.answer && item.question),
   );
-};
+}
 
 export const usePromptsData = () => {
   const { data: activeWorkspaceName } = useActiveWorkspaceName();
@@ -26,6 +26,6 @@ export const usePromptsData = () => {
 
   return useQuery({
     ...v1GetWorkspaceMessagesOptions(options),
-    select: selectConversations,
+    select: select,
   });
 };


### PR DESCRIPTION
* While working on #230 I noticed that we weren't following some [best-practices](https://tanstack.com/query/latest/docs/framework/react/guides/render-optimizations#memoization) around use of the `select` parameter for react-query's `useQuery` hook:

>The select function will only re-run if:
> - the select function itself changed referentially
> - data changed
> This means that an inlined select function, as shown above, will run on every render. To avoid this, you can wrap the select function in useCallback, or extract it to a stable function reference if it doesn't have any dependencies

* This fixes any usage errors throughout the codebase (mainly created by me :D) and documents them, to attempt to avoid any regressions.