### PR TITLE
fix: implement default caching options for react-query

### DIFF
--- a/src/components/react-query-provider.tsx
+++ b/src/components/react-query-provider.tsx
@@ -1,5 +1,6 @@
 import { V1ListActiveWorkspacesResponse } from "@/api/generated";
 import { v1ListActiveWorkspacesQueryKey } from "@/api/generated/@tanstack/react-query.gen";
+import { getQueryCacheConfig } from "@/lib/react-query-utils";
 import {
   QueryCacheNotifyEvent,
   QueryClient,
@@ -36,7 +37,16 @@ export function QueryClientProvider({ children }: { children: ReactNode }) {
     null,
   );
 
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            ...getQueryCacheConfig("short"),
+          },
+        },
+      }),
+  );
 
   useEffect(() => {
     const queryCache = queryClient.getQueryCache();

--- a/src/lib/react-query-utils.ts
+++ b/src/lib/react-query-utils.ts
@@ -1,6 +1,10 @@
 import { OpenApiTsReactQueryKey } from "@/types/openapi-ts";
 import { OptionsLegacyParser } from "@hey-api/client-fetch";
-import { Query, QueryClient } from "@tanstack/react-query";
+import {
+  Query,
+  QueryClient,
+  QueryObserverOptions,
+} from "@tanstack/react-query";
 
 // NOTE: This is copy/pasted from @/api/generated/@tanstack/react-query.gen
 type QueryKey<TOptions extends OptionsLegacyParser = OptionsLegacyParser> = [
@@ -33,6 +37,7 @@ export function invalidateQueries(
 ) {
   return queryClient.invalidateQueries({
     refetchType: "all",
+    stale: true,
     predicate: (
       query: Query<unknown, Error, unknown, OpenApiTsReactQueryKey>,
     ) => {
@@ -41,4 +46,28 @@ export function invalidateQueries(
       );
     },
   });
+}
+
+export function getQueryCacheConfig(
+  lifetime: "dynamic" | "short" | "indefinite",
+) {
+  switch (lifetime) {
+    case "dynamic":
+      return {
+        staleTime: 0,
+      } as const satisfies Pick<QueryObserverOptions, "staleTime">;
+
+    case "short":
+      return {
+        staleTime: 5 * 1_000,
+      } as const satisfies Pick<QueryObserverOptions, "staleTime">;
+
+    case "indefinite":
+      return {
+        staleTime: Infinity,
+      } as const satisfies Pick<QueryObserverOptions, "staleTime">;
+
+    default:
+      return lifetime satisfies never;
+  }
 }


### PR DESCRIPTION
- adds a helper for setting cache lifetime of data fetched with react-query 
- applies it globally as `defaultSettings` to all queries (can be overridden each time we call `useQuery`)
- fixes #250 
- workaround for https://github.com/stacklok/codegate/issues/936

