### PR TITLE
feat: enable word wrap for prompt editor

### DIFF
--- a/src/features/workspace/components/workspace-custom-instructions.tsx
+++ b/src/features/workspace/components/workspace-custom-instructions.tsx
@@ -334,6 +334,7 @@ export function WorkspaceCustomInstructions({
               <Editor
                 options={{
                   minimap: { enabled: false },
+                  wordWrap: "on",
                   readOnly: isArchived,
                 }}
                 value={values.prompt}


### PR DESCRIPTION
I think enabling word wrap is a better default, because I found that it's annoying otherwise.

## Before

![Screenshot_select-area_20250213143532](https://github.com/user-attachments/assets/392edeee-67f1-4b9c-b996-aa5ff9914b83)


## After

![Screenshot_select-area_20250213143756](https://github.com/user-attachments/assets/daca1150-55d8-4d61-b413-bfeacb66727d)
