### PR TITLE
docs: small updates for the cert instructions

### DIFF
--- a/src/markdown/certificates/linux-install.md
+++ b/src/markdown/certificates/linux-install.md
@@ -1,12 +1,10 @@
-1. Install the `certutil` tool using the appropriate command for your distribution: 
-   - **Ubuntu/Debian**: `sudo apt install libnss3-tools` 
+1. Install the `certutil` tool using the appropriate command for your distribution:
+   - **Ubuntu/Debian**: `sudo apt install libnss3-tools`
    - **RHEL/Fedora**: `sudo dnf install nss-tools`
-2. Run the following command to install the certificate for your account:
+2. Add the certificate to your account's NSS shared database:
     ```shell
     certutil -d sql:$HOME/.pki/nssdb \
-    -A \
-    -t "C,," \
-    -n CodeGate-CA \
-    -i ~/Downloads/codegate.crt
+      -A -t "C,," -n CodeGate-CA \
+      -i ~/Downloads/codegate.crt
     ```
 3. Restart VS Code.

--- a/src/markdown/certificates/linux-remove.md
+++ b/src/markdown/certificates/linux-remove.md
@@ -1,4 +1,4 @@
-1. Run the following command to uninstall the certificate from your account:
+1. Remove the certificate from your account:
     ```shell
     certutil -d sql:$HOME/.pki/nssdb -D -n CodeGate-CA
     ```

--- a/src/markdown/certificates/macos-install.md
+++ b/src/markdown/certificates/macos-install.md
@@ -1,4 +1,4 @@
-### Option 1: CLI
+### CLI method
 
 After downloading the certificate, open a terminal and run:
 
@@ -8,7 +8,7 @@ security add-trusted-cert -d -r trustRoot -p ssl -p basic \
   ~/Downloads/codegate.crt
 ```
 
-### Option 2: GUI
+### GUI method
 
 1. Open the downloaded certificate file; Keychain Access will open.
 2. Depending on your macOS version, you may see the **Add Certificates** dialog. If so, select the `login` keychain and click **Add**.

--- a/src/markdown/certificates/macos-install.md
+++ b/src/markdown/certificates/macos-install.md
@@ -1,21 +1,17 @@
-### CLI method
+### Option 1: CLI
 
-After downloading the certificate, open a terminal and run the following command:
+After downloading the certificate, open a terminal and run:
 
 ```shell
-security add-trusted-cert \
--d \
--r trustRoot \
--p ssl \
--p basic \
--k ~/Library/Keychains/login.keychain \
-~/Downloads/codegate.crt
+security add-trusted-cert -d -r trustRoot -p ssl -p basic \
+  -k ~/Library/Keychains/login.keychain \
+  ~/Downloads/codegate.crt
 ```
 
-### GUI method
+### Option 2: GUI
 
 1. Open the downloaded certificate file; Keychain Access will open.
-2. Depending on your macOS version, you may see the Add Certificates dialog. If so, select the `login` keychain, and click Add.
-3. In Keychain Access, select the `login` keychain from the Default Keychains list on the left.
-4. Search for "CodeGate" (it may not appear until you search), then in the search results, double-click the "CodeGate CA" certificate.
-5. Expand the Trust section and set the "Secure Sockets Layer" and "X.509 Basic Policy" options to "Always Trust".
+2. Depending on your macOS version, you may see the **Add Certificates** dialog. If so, select the `login` keychain and click **Add**.
+3. In Keychain Access, select the **login** keychain from the list on the left.
+4. Search for "CodeGate" (it may not appear until you search), then double-click the "CodeGate CA" certificate in the search results.
+5. Expand the **Trust** section and set the "Secure Sockets Layer" and "X.509 Basic Policy" options to **Always Trust**.

--- a/src/markdown/certificates/macos-remove.md
+++ b/src/markdown/certificates/macos-remove.md
@@ -1,16 +1,15 @@
 ### CLI method
 
-Open a terminal and run the following command:
-  
+Open a terminal and run:
+
 ```shell
-security delete-certificate \
--c "CodeGate CA" \
--t ~/Library/Keychains/login.keychain
+security delete-certificate -c "CodeGate CA" \
+  -t ~/Library/Keychains/login.keychain
 ```
 
 ### GUI method
 
-1. Launch the Keychain Access app (Note: on newer macOS versions, Keychain Access is hidden from Launcher, but can be run from Spotlight Search).
-2. Select the login keychain and search for "CodeGate".
-3. Right-click the "CodeGate CA" certificate and Delete the certificate.
+1. Launch the **Keychain Access** app. Note: on newer macOS versions, Keychain Access is hidden from Launcher but can be opened from Spotlight Search.
+2. Select the **login** keychain and search for "CodeGate".
+3. Right-click the "CodeGate CA" certificate and select **Delete "CodeGate CA"**.
 4. Confirm the deletion when prompted.

--- a/src/markdown/certificates/windows-install.md
+++ b/src/markdown/certificates/windows-install.md
@@ -1,6 +1,6 @@
 1. Double-click the downloaded certificate file.
-2. Click "Install Certificate".
-3. Select "Current User" and click Next.
+2. Click **Install Certificate**.
+3. Select "Current User" and click **Next**.
 4. Choose "Place all certificates in the following store".
-5. Click Browse and select "Trusted Root Certification Authorities".
-6. Click Next and Finish.
+5. Click **Browse** and select "Trusted Root Certification Authorities".
+6. Click **Next** and then **Finish**.

--- a/src/markdown/certificates/windows-remove.md
+++ b/src/markdown/certificates/windows-remove.md
@@ -1,5 +1,5 @@
 1. Open "Run" (Win + R) and enter `certmgr.msc`.
 2. Navigate to "Trusted Root Certification Authorities" → "Certificates".
 3. Find the "CodeGate CA" certificate.
-4. Right-click and Delete the certificate.
+4. Right-click the certificate and select **Delete**.
 5. Confirm the deletion when prompted.

--- a/src/routes/__tests__/route-certificates.test.tsx
+++ b/src/routes/__tests__/route-certificates.test.tsx
@@ -60,7 +60,9 @@ describe('Certificates', () => {
     ).toBeVisible()
     expect(screen.getByRole('heading', { name: 'GUI method' })).toBeVisible()
     expect(
-      screen.getByText('Launch the Keychain Access app', { exact: false })
+      screen.getByText('Right-click the "CodeGate CA" certificate', {
+        exact: false,
+      })
     ).toBeVisible()
   })
 
@@ -86,7 +88,7 @@ describe('Certificates', () => {
 
     expect(
       screen.getByText(
-        'Run the following command to install the certificate for your account:'
+        "Add the certificate to your account's NSS shared database:"
       )
     ).toBeVisible()
 
@@ -94,9 +96,7 @@ describe('Certificates', () => {
       screen.getByRole('button', { name: 'Remove certificate' })
     )
     expect(
-      screen.getByText(
-        'Run the following command to uninstall the certificate from your account:'
-      )
+      screen.getByText('Remove the certificate from your account:')
     ).toBeVisible()
   })
 })


### PR DESCRIPTION
- Use docs style to use bold for UI elements now that we have
  markdown support
- Tighten up the CLI line breaks a bit
- Minor wording updates