### PR TITLE
fix: id format for provider, model muxing rule

### DIFF
--- a/src/features/workspace/components/workspace-models-dropdown.tsx
+++ b/src/features/workspace/components/workspace-models-dropdown.tsx
@@ -37,7 +37,7 @@ function groupModelsByProviderName(
     id: providerName,
     textValue: providerName,
     items: items.map((item) => ({
-      id: `${item.provider_id}:${item.name}`,
+      id: `${item.provider_id}+${item.name}`,
       textValue: item.name,
     })),
   }))
@@ -116,7 +116,7 @@ export function WorkspaceModelsDropdown({
               const selectedValue = v.values().next().value
               if (!selectedValue && typeof selectedValue !== 'string') return
               if (typeof selectedValue === 'string') {
-                const [provider_id, modelName] = selectedValue.split(':')
+                const [provider_id, modelName] = selectedValue.split('+')
                 if (!provider_id || !modelName) return
                 onChange({
                   model: modelName,


### PR DESCRIPTION
Replaced `id` muxing dropdown using `+` rather than `:`. The `:` is used by Ollama model. Actually the providers are using different model name format, we would thing to add a `model_id` for fix this.

<img width="1710" alt="Screenshot 2025-03-03 at 08 58 43" src="https://github.com/user-attachments/assets/eec01f79-2980-4195-8bc2-54185d0b75a0" />
