### PR TITLE
fix: handle breaking changes in frontend for "workspaces by provider" endpoint

### DIFF
--- a/src/api/generated/@tanstack/react-query.gen.ts
+++ b/src/api/generated/@tanstack/react-query.gen.ts
@@ -19,20 +19,26 @@ import {
   v1ActivateWorkspace,
   v1UpdateWorkspace,
   v1DeleteWorkspace,
+  v1GetWorkspaceByName,
   v1ListArchivedWorkspaces,
   v1RecoverWorkspace,
   v1HardDeleteWorkspace,
   v1GetWorkspaceAlerts,
+  v1GetWorkspaceAlertsSummary,
   v1GetWorkspaceMessages,
   v1GetWorkspaceCustomInstructions,
   v1SetWorkspaceCustomInstructions,
   v1DeleteWorkspaceCustomInstructions,
   v1GetWorkspaceMuxes,
   v1SetWorkspaceMuxes,
-  v1ListWorkspacesByProvider,
   v1StreamSse,
   v1VersionCheck,
   v1GetWorkspaceTokenUsage,
+  v1ListPersonas,
+  v1CreatePersona,
+  v1GetPersona,
+  v1UpdatePersona,
+  v1DeletePersona,
 } from '../sdk.gen'
 import type {
   V1ListProviderEndpointsData,
@@ -50,6 +56,7 @@ import type {
   V1ConfigureAuthMaterialData,
   V1ConfigureAuthMaterialError,
   V1ConfigureAuthMaterialResponse,
+  V1ListWorkspacesData,
   V1CreateWorkspaceData,
   V1CreateWorkspaceError,
   V1CreateWorkspaceResponse,
@@ -62,6 +69,7 @@ import type {
   V1DeleteWorkspaceData,
   V1DeleteWorkspaceError,
   V1DeleteWorkspaceResponse,
+  V1GetWorkspaceByNameData,
   V1RecoverWorkspaceData,
   V1RecoverWorkspaceError,
   V1RecoverWorkspaceResponse,
@@ -69,6 +77,7 @@ import type {
   V1HardDeleteWorkspaceError,
   V1HardDeleteWorkspaceResponse,
   V1GetWorkspaceAlertsData,
+  V1GetWorkspaceAlertsSummaryData,
   V1GetWorkspaceMessagesData,
   V1GetWorkspaceCustomInstructionsData,
   V1SetWorkspaceCustomInstructionsData,
@@ -81,8 +90,17 @@ import type {
   V1SetWorkspaceMuxesData,
   V1SetWorkspaceMuxesError,
   V1SetWorkspaceMuxesResponse,
-  V1ListWorkspacesByProviderData,
   V1GetWorkspaceTokenUsageData,
+  V1CreatePersonaData,
+  V1CreatePersonaError,
+  V1CreatePersonaResponse,
+  V1GetPersonaData,
+  V1UpdatePersonaData,
+  V1UpdatePersonaError,
+  V1UpdatePersonaResponse,
+  V1DeletePersonaData,
+  V1DeletePersonaError,
+  V1DeletePersonaResponse,
 } from '../types.gen'
 
 type QueryKey<TOptions extends OptionsLegacyParser> = [
@@ -323,11 +341,13 @@ export const v1ConfigureAuthMaterialMutation = (
   return mutationOptions
 }
 
-export const v1ListWorkspacesQueryKey = (options?: OptionsLegacyParser) => [
-  createQueryKey('v1ListWorkspaces', options),
-]
+export const v1ListWorkspacesQueryKey = (
+  options?: OptionsLegacyParser<V1ListWorkspacesData>
+) => [createQueryKey('v1ListWorkspaces', options)]
 
-export const v1ListWorkspacesOptions = (options?: OptionsLegacyParser) => {
+export const v1ListWorkspacesOptions = (
+  options?: OptionsLegacyParser<V1ListWorkspacesData>
+) => {
   return queryOptions({
     queryFn: async ({ queryKey, signal }) => {
       const { data } = await v1ListWorkspaces({
@@ -485,6 +505,27 @@ export const v1DeleteWorkspaceMutation = (
   return mutationOptions
 }
 
+export const v1GetWorkspaceByNameQueryKey = (
+  options: OptionsLegacyParser<V1GetWorkspaceByNameData>
+) => [createQueryKey('v1GetWorkspaceByName', options)]
+
+export const v1GetWorkspaceByNameOptions = (
+  options: OptionsLegacyParser<V1GetWorkspaceByNameData>
+) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await v1GetWorkspaceByName({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      })
+      return data
+    },
+    queryKey: v1GetWorkspaceByNameQueryKey(options),
+  })
+}
+
 export const v1ListArchivedWorkspacesQueryKey = (
   options?: OptionsLegacyParser
 ) => [createQueryKey('v1ListArchivedWorkspaces', options)]
@@ -585,6 +626,27 @@ export const v1GetWorkspaceAlertsOptions = (
       return data
     },
     queryKey: v1GetWorkspaceAlertsQueryKey(options),
+  })
+}
+
+export const v1GetWorkspaceAlertsSummaryQueryKey = (
+  options: OptionsLegacyParser<V1GetWorkspaceAlertsSummaryData>
+) => [createQueryKey('v1GetWorkspaceAlertsSummary', options)]
+
+export const v1GetWorkspaceAlertsSummaryOptions = (
+  options: OptionsLegacyParser<V1GetWorkspaceAlertsSummaryData>
+) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await v1GetWorkspaceAlertsSummary({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      })
+      return data
+    },
+    queryKey: v1GetWorkspaceAlertsSummaryQueryKey(options),
   })
 }
 
@@ -713,27 +775,6 @@ export const v1SetWorkspaceMuxesMutation = (
   return mutationOptions
 }
 
-export const v1ListWorkspacesByProviderQueryKey = (
-  options: OptionsLegacyParser<V1ListWorkspacesByProviderData>
-) => [createQueryKey('v1ListWorkspacesByProvider', options)]
-
-export const v1ListWorkspacesByProviderOptions = (
-  options: OptionsLegacyParser<V1ListWorkspacesByProviderData>
-) => {
-  return queryOptions({
-    queryFn: async ({ queryKey, signal }) => {
-      const { data } = await v1ListWorkspacesByProvider({
-        ...options,
-        ...queryKey[0],
-        signal,
-        throwOnError: true,
-      })
-      return data
-    },
-    queryKey: v1ListWorkspacesByProviderQueryKey(options),
-  })
-}
-
 export const v1StreamSseQueryKey = (options?: OptionsLegacyParser) => [
   createQueryKey('v1StreamSse', options),
 ]
@@ -791,4 +832,125 @@ export const v1GetWorkspaceTokenUsageOptions = (
     },
     queryKey: v1GetWorkspaceTokenUsageQueryKey(options),
   })
+}
+
+export const v1ListPersonasQueryKey = (options?: OptionsLegacyParser) => [
+  createQueryKey('v1ListPersonas', options),
+]
+
+export const v1ListPersonasOptions = (options?: OptionsLegacyParser) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await v1ListPersonas({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      })
+      return data
+    },
+    queryKey: v1ListPersonasQueryKey(options),
+  })
+}
+
+export const v1CreatePersonaQueryKey = (
+  options: OptionsLegacyParser<V1CreatePersonaData>
+) => [createQueryKey('v1CreatePersona', options)]
+
+export const v1CreatePersonaOptions = (
+  options: OptionsLegacyParser<V1CreatePersonaData>
+) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await v1CreatePersona({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      })
+      return data
+    },
+    queryKey: v1CreatePersonaQueryKey(options),
+  })
+}
+
+export const v1CreatePersonaMutation = (
+  options?: Partial<OptionsLegacyParser<V1CreatePersonaData>>
+) => {
+  const mutationOptions: UseMutationOptions<
+    V1CreatePersonaResponse,
+    V1CreatePersonaError,
+    OptionsLegacyParser<V1CreatePersonaData>
+  > = {
+    mutationFn: async (localOptions) => {
+      const { data } = await v1CreatePersona({
+        ...options,
+        ...localOptions,
+        throwOnError: true,
+      })
+      return data
+    },
+  }
+  return mutationOptions
+}
+
+export const v1GetPersonaQueryKey = (
+  options: OptionsLegacyParser<V1GetPersonaData>
+) => [createQueryKey('v1GetPersona', options)]
+
+export const v1GetPersonaOptions = (
+  options: OptionsLegacyParser<V1GetPersonaData>
+) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await v1GetPersona({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      })
+      return data
+    },
+    queryKey: v1GetPersonaQueryKey(options),
+  })
+}
+
+export const v1UpdatePersonaMutation = (
+  options?: Partial<OptionsLegacyParser<V1UpdatePersonaData>>
+) => {
+  const mutationOptions: UseMutationOptions<
+    V1UpdatePersonaResponse,
+    V1UpdatePersonaError,
+    OptionsLegacyParser<V1UpdatePersonaData>
+  > = {
+    mutationFn: async (localOptions) => {
+      const { data } = await v1UpdatePersona({
+        ...options,
+        ...localOptions,
+        throwOnError: true,
+      })
+      return data
+    },
+  }
+  return mutationOptions
+}
+
+export const v1DeletePersonaMutation = (
+  options?: Partial<OptionsLegacyParser<V1DeletePersonaData>>
+) => {
+  const mutationOptions: UseMutationOptions<
+    V1DeletePersonaResponse,
+    V1DeletePersonaError,
+    OptionsLegacyParser<V1DeletePersonaData>
+  > = {
+    mutationFn: async (localOptions) => {
+      const { data } = await v1DeletePersona({
+        ...options,
+        ...localOptions,
+        throwOnError: true,
+      })
+      return data
+    },
+  }
+  return mutationOptions
 }

--- a/src/api/generated/sdk.gen.ts
+++ b/src/api/generated/sdk.gen.ts
@@ -31,6 +31,7 @@ import type {
   V1ConfigureAuthMaterialData,
   V1ConfigureAuthMaterialError,
   V1ConfigureAuthMaterialResponse,
+  V1ListWorkspacesData,
   V1ListWorkspacesError,
   V1ListWorkspacesResponse,
   V1CreateWorkspaceData,
@@ -47,6 +48,9 @@ import type {
   V1DeleteWorkspaceData,
   V1DeleteWorkspaceError,
   V1DeleteWorkspaceResponse,
+  V1GetWorkspaceByNameData,
+  V1GetWorkspaceByNameError,
+  V1GetWorkspaceByNameResponse,
   V1ListArchivedWorkspacesError,
   V1ListArchivedWorkspacesResponse,
   V1RecoverWorkspaceData,
@@ -58,6 +62,9 @@ import type {
   V1GetWorkspaceAlertsData,
   V1GetWorkspaceAlertsError,
   V1GetWorkspaceAlertsResponse,
+  V1GetWorkspaceAlertsSummaryData,
+  V1GetWorkspaceAlertsSummaryError,
+  V1GetWorkspaceAlertsSummaryResponse,
   V1GetWorkspaceMessagesData,
   V1GetWorkspaceMessagesError,
   V1GetWorkspaceMessagesResponse,
@@ -76,9 +83,6 @@ import type {
   V1SetWorkspaceMuxesData,
   V1SetWorkspaceMuxesError,
   V1SetWorkspaceMuxesResponse,
-  V1ListWorkspacesByProviderData,
-  V1ListWorkspacesByProviderError,
-  V1ListWorkspacesByProviderResponse,
   V1StreamSseError,
   V1StreamSseResponse,
   V1VersionCheckError,
@@ -86,6 +90,20 @@ import type {
   V1GetWorkspaceTokenUsageData,
   V1GetWorkspaceTokenUsageError,
   V1GetWorkspaceTokenUsageResponse,
+  V1ListPersonasError,
+  V1ListPersonasResponse,
+  V1CreatePersonaData,
+  V1CreatePersonaError,
+  V1CreatePersonaResponse,
+  V1GetPersonaData,
+  V1GetPersonaError,
+  V1GetPersonaResponse,
+  V1UpdatePersonaData,
+  V1UpdatePersonaError,
+  V1UpdatePersonaResponse,
+  V1DeletePersonaData,
+  V1DeletePersonaError,
+  V1DeletePersonaResponse,
 } from './types.gen'
 
 export const client = createClient(createConfig())
@@ -247,9 +265,18 @@ export const v1ConfigureAuthMaterial = <ThrowOnError extends boolean = false>(
 /**
  * List Workspaces
  * List all workspaces.
+ *
+ * Args:
+ * provider_id (Optional[UUID]): Filter workspaces by provider ID. If provided,
+ * will return workspaces where models from the specified provider (e.g., OpenAI,
+ * Anthropic) have been used in workspace muxing rules. Note that you must
+ * refer to a provider by ID, not by name.
+ *
+ * Returns:
+ * ListWorkspacesResponse: A response object containing the list of workspaces.
  */
 export const v1ListWorkspaces = <ThrowOnError extends boolean = false>(
-  options?: OptionsLegacyParser<unknown, ThrowOnError>
+  options?: OptionsLegacyParser<V1ListWorkspacesData, ThrowOnError>
 ) => {
   return (options?.client ?? client).get<
     V1ListWorkspacesResponse,
@@ -350,6 +377,23 @@ export const v1DeleteWorkspace = <ThrowOnError extends boolean = false>(
 }
 
 /**
+ * Get Workspace By Name
+ * List workspaces by provider ID.
+ */
+export const v1GetWorkspaceByName = <ThrowOnError extends boolean = false>(
+  options: OptionsLegacyParser<V1GetWorkspaceByNameData, ThrowOnError>
+) => {
+  return (options?.client ?? client).get<
+    V1GetWorkspaceByNameResponse,
+    V1GetWorkspaceByNameError,
+    ThrowOnError
+  >({
+    ...options,
+    url: '/api/v1/workspaces/{workspace_name}',
+  })
+}
+
+/**
  * List Archived Workspaces
  * List all archived workspaces.
  */
@@ -414,6 +458,25 @@ export const v1GetWorkspaceAlerts = <ThrowOnError extends boolean = false>(
   >({
     ...options,
     url: '/api/v1/workspaces/{workspace_name}/alerts',
+  })
+}
+
+/**
+ * Get Workspace Alerts Summary
+ * Get alert summary for a workspace.
+ */
+export const v1GetWorkspaceAlertsSummary = <
+  ThrowOnError extends boolean = false,
+>(
+  options: OptionsLegacyParser<V1GetWorkspaceAlertsSummaryData, ThrowOnError>
+) => {
+  return (options?.client ?? client).get<
+    V1GetWorkspaceAlertsSummaryResponse,
+    V1GetWorkspaceAlertsSummaryError,
+    ThrowOnError
+  >({
+    ...options,
+    url: '/api/v1/workspaces/{workspace_name}/alerts-summary',
   })
 }
 
@@ -536,25 +599,6 @@ export const v1SetWorkspaceMuxes = <ThrowOnError extends boolean = false>(
 }
 
 /**
- * List Workspaces By Provider
- * List workspaces by provider ID.
- */
-export const v1ListWorkspacesByProvider = <
-  ThrowOnError extends boolean = false,
->(
-  options: OptionsLegacyParser<V1ListWorkspacesByProviderData, ThrowOnError>
-) => {
-  return (options?.client ?? client).get<
-    V1ListWorkspacesByProviderResponse,
-    V1ListWorkspacesByProviderError,
-    ThrowOnError
-  >({
-    ...options,
-    url: '/api/v1/workspaces/{provider_id}',
-  })
-}
-
-/**
  * Stream Sse
  * Send alerts event
  */
@@ -601,5 +645,90 @@ export const v1GetWorkspaceTokenUsage = <ThrowOnError extends boolean = false>(
   >({
     ...options,
     url: '/api/v1/workspaces/{workspace_name}/token-usage',
+  })
+}
+
+/**
+ * List Personas
+ * List all personas.
+ */
+export const v1ListPersonas = <ThrowOnError extends boolean = false>(
+  options?: OptionsLegacyParser<unknown, ThrowOnError>
+) => {
+  return (options?.client ?? client).get<
+    V1ListPersonasResponse,
+    V1ListPersonasError,
+    ThrowOnError
+  >({
+    ...options,
+    url: '/api/v1/personas',
+  })
+}
+
+/**
+ * Create Persona
+ * Create a new persona.
+ */
+export const v1CreatePersona = <ThrowOnError extends boolean = false>(
+  options: OptionsLegacyParser<V1CreatePersonaData, ThrowOnError>
+) => {
+  return (options?.client ?? client).post<
+    V1CreatePersonaResponse,
+    V1CreatePersonaError,
+    ThrowOnError
+  >({
+    ...options,
+    url: '/api/v1/personas',
+  })
+}
+
+/**
+ * Get Persona
+ * Get a persona by name.
+ */
+export const v1GetPersona = <ThrowOnError extends boolean = false>(
+  options: OptionsLegacyParser<V1GetPersonaData, ThrowOnError>
+) => {
+  return (options?.client ?? client).get<
+    V1GetPersonaResponse,
+    V1GetPersonaError,
+    ThrowOnError
+  >({
+    ...options,
+    url: '/api/v1/personas/{persona_name}',
+  })
+}
+
+/**
+ * Update Persona
+ * Update an existing persona.
+ */
+export const v1UpdatePersona = <ThrowOnError extends boolean = false>(
+  options: OptionsLegacyParser<V1UpdatePersonaData, ThrowOnError>
+) => {
+  return (options?.client ?? client).put<
+    V1UpdatePersonaResponse,
+    V1UpdatePersonaError,
+    ThrowOnError
+  >({
+    ...options,
+    url: '/api/v1/personas/{persona_name}',
+  })
+}
+
+/**
+ * Delete Persona
+ * Delete a persona.
+ */
+export const v1DeletePersona = <ThrowOnError extends boolean = false>(
+  options: OptionsLegacyParser<V1DeletePersonaData, ThrowOnError>
+) => {
+  return (options?.client ?? client).delete<
+    V1DeletePersonaResponse,
+    V1DeletePersonaError,
+    ThrowOnError
+  >({
+    ...options,
+    url: '/api/v1/personas/{persona_name}',
   })
 }

--- a/src/api/generated/types.gen.ts
+++ b/src/api/generated/types.gen.ts
@@ -65,6 +65,15 @@ export enum AlertSeverity {
 }
 
 /**
+ * Represents a set of summary alerts
+ */
+export type AlertSummary = {
+  malicious_packages: number
+  pii: number
+  secrets: number
+}
+
+/**
  * Represents a chat message.
  */
 export type ChatMessage = {
@@ -179,6 +188,31 @@ export type MuxRule = {
 }
 
 /**
+ * Represents a persona object.
+ */
+export type Persona = {
+  id: string
+  name: string
+  description: string
+}
+
+/**
+ * Model for creating a new Persona.
+ */
+export type PersonaRequest = {
+  name: string
+  description: string
+}
+
+/**
+ * Model for updating a Persona.
+ */
+export type PersonaUpdateRequest = {
+  new_name: string
+  new_description: string
+}
+
+/**
  * Represents the different types of auth we support for providers.
  */
 export enum ProviderAuthType {
@@ -279,15 +313,6 @@ export type WorkspaceConfig_Output = {
   muxing_rules: Array<MuxRule>
 }
 
-/**
- * Returns a workspace ID with model name
- */
-export type WorkspaceWithModel = {
-  id: string
-  name: string
-  provider_model_name: string
-}
-
 export type HealthCheckHealthGetResponse = unknown
 
 export type HealthCheckHealthGetError = unknown
@@ -366,9 +391,15 @@ export type V1ConfigureAuthMaterialResponse = void
 
 export type V1ConfigureAuthMaterialError = HTTPValidationError
 
+export type V1ListWorkspacesData = {
+  query?: {
+    provider_id?: string | null
+  }
+}
+
 export type V1ListWorkspacesResponse = ListWorkspacesResponse
 
-export type V1ListWorkspacesError = unknown
+export type V1ListWorkspacesError = HTTPValidationError
 
 export type V1CreateWorkspaceData = {
   body: FullWorkspace_Input
@@ -414,6 +445,16 @@ export type V1DeleteWorkspaceResponse = unknown
 
 export type V1DeleteWorkspaceError = HTTPValidationError
 
+export type V1GetWorkspaceByNameData = {
+  path: {
+    workspace_name: string
+  }
+}
+
+export type V1GetWorkspaceByNameResponse = FullWorkspace_Output
+
+export type V1GetWorkspaceByNameError = HTTPValidationError
+
 export type V1ListArchivedWorkspacesResponse = ListWorkspacesResponse
 
 export type V1ListArchivedWorkspacesError = unknown
@@ -447,6 +488,16 @@ export type V1GetWorkspaceAlertsData = {
 export type V1GetWorkspaceAlertsResponse = Array<AlertConversation | null>
 
 export type V1GetWorkspaceAlertsError = HTTPValidationError
+
+export type V1GetWorkspaceAlertsSummaryData = {
+  path: {
+    workspace_name: string
+  }
+}
+
+export type V1GetWorkspaceAlertsSummaryResponse = AlertSummary
+
+export type V1GetWorkspaceAlertsSummaryError = HTTPValidationError
 
 export type V1GetWorkspaceMessagesData = {
   path: {
@@ -510,16 +561,6 @@ export type V1SetWorkspaceMuxesResponse = void
 
 export type V1SetWorkspaceMuxesError = HTTPValidationError
 
-export type V1ListWorkspacesByProviderData = {
-  path: {
-    provider_id: string
-  }
-}
-
-export type V1ListWorkspacesByProviderResponse = Array<WorkspaceWithModel>
-
-export type V1ListWorkspacesByProviderError = HTTPValidationError
-
 export type V1StreamSseResponse = unknown
 
 export type V1StreamSseError = unknown
@@ -537,3 +578,46 @@ export type V1GetWorkspaceTokenUsageData = {
 export type V1GetWorkspaceTokenUsageResponse = TokenUsageAggregate
 
 export type V1GetWorkspaceTokenUsageError = HTTPValidationError
+
+export type V1ListPersonasResponse = Array<Persona>
+
+export type V1ListPersonasError = unknown
+
+export type V1CreatePersonaData = {
+  body: PersonaRequest
+}
+
+export type V1CreatePersonaResponse = Persona
+
+export type V1CreatePersonaError = HTTPValidationError
+
+export type V1GetPersonaData = {
+  path: {
+    persona_name: string
+  }
+}
+
+export type V1GetPersonaResponse = Persona
+
+export type V1GetPersonaError = HTTPValidationError
+
+export type V1UpdatePersonaData = {
+  body: PersonaUpdateRequest
+  path: {
+    persona_name: string
+  }
+}
+
+export type V1UpdatePersonaResponse = Persona
+
+export type V1UpdatePersonaError = HTTPValidationError
+
+export type V1DeletePersonaData = {
+  path: {
+    persona_name: string
+  }
+}
+
+export type V1DeletePersonaResponse = void
+
+export type V1DeletePersonaError = HTTPValidationError

--- a/src/api/openapi.json
+++ b/src/api/openapi.json
@@ -362,8 +362,27 @@
       "get": {
         "tags": ["CodeGate API", "Workspaces"],
         "summary": "List Workspaces",
-        "description": "List all workspaces.",
+        "description": "List all workspaces.\n\nArgs:\n    provider_id (Optional[UUID]): Filter workspaces by provider ID. If provided,\n    will return workspaces where models from the specified provider (e.g., OpenAI,\n    Anthropic) have been used in workspace muxing rules. Note that you must\n    refer to a provider by ID, not by name.\n\nReturns:\n    ListWorkspacesResponse: A response object containing the list of workspaces.",
         "operationId": "v1_list_workspaces",
+        "parameters": [
+          {
+            "name": "provider_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Provider Id"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -371,6 +390,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListWorkspacesResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -383,14 +412,14 @@
         "description": "Create a new workspace.",
         "operationId": "v1_create_workspace",
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/FullWorkspace-Input"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "201": {
@@ -569,6 +598,45 @@
             }
           }
         }
+      },
+      "get": {
+        "tags": ["CodeGate API", "Workspaces"],
+        "summary": "Get Workspace By Name",
+        "description": "List workspaces by provider ID.",
+        "operationId": "v1_get_workspace_by_name",
+        "parameters": [
+          {
+            "name": "workspace_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FullWorkspace-Output"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/v1/workspaces/archive": {
@@ -699,6 +767,47 @@
                     ]
                   },
                   "title": "Response V1 Get Workspace Alerts"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workspaces/{workspace_name}/alerts-summary": {
+      "get": {
+        "tags": ["CodeGate API", "Workspaces"],
+        "summary": "Get Workspace Alerts Summary",
+        "description": "Get alert summary for a workspace.",
+        "operationId": "v1_get_workspace_alerts_summary",
+        "parameters": [
+          {
+            "name": "workspace_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertSummary"
                 }
               }
             }
@@ -965,52 +1074,6 @@
         }
       }
     },
-    "/api/v1/workspaces/{provider_id}": {
-      "get": {
-        "tags": ["CodeGate API", "Workspaces"],
-        "summary": "List Workspaces By Provider",
-        "description": "List workspaces by provider ID.",
-        "operationId": "v1_list_workspaces_by_provider",
-        "parameters": [
-          {
-            "name": "provider_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Provider Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/WorkspaceWithModel"
-                  },
-                  "title": "Response V1 List Workspaces By Provider"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/alerts_notification": {
       "get": {
         "tags": ["CodeGate API", "Dashboard"],
@@ -1073,6 +1136,190 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/personas": {
+      "get": {
+        "tags": ["CodeGate API", "Personas"],
+        "summary": "List Personas",
+        "description": "List all personas.",
+        "operationId": "v1_list_personas",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Persona"
+                  },
+                  "type": "array",
+                  "title": "Response V1 List Personas"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["CodeGate API", "Personas"],
+        "summary": "Create Persona",
+        "description": "Create a new persona.",
+        "operationId": "v1_create_persona",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PersonaRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Persona"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/personas/{persona_name}": {
+      "get": {
+        "tags": ["CodeGate API", "Personas"],
+        "summary": "Get Persona",
+        "description": "Get a persona by name.",
+        "operationId": "v1_get_persona",
+        "parameters": [
+          {
+            "name": "persona_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Persona Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Persona"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["CodeGate API", "Personas"],
+        "summary": "Update Persona",
+        "description": "Update an existing persona.",
+        "operationId": "v1_update_persona",
+        "parameters": [
+          {
+            "name": "persona_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Persona Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PersonaUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Persona"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["CodeGate API", "Personas"],
+        "summary": "Delete Persona",
+        "description": "Delete a persona.",
+        "operationId": "v1_delete_persona",
+        "parameters": [
+          {
+            "name": "persona_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Persona Name"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
           },
           "422": {
             "description": "Validation Error",
@@ -1302,6 +1549,26 @@
         "type": "string",
         "enum": ["info", "critical"],
         "title": "AlertSeverity"
+      },
+      "AlertSummary": {
+        "properties": {
+          "malicious_packages": {
+            "type": "integer",
+            "title": "Malicious Packages"
+          },
+          "pii": {
+            "type": "integer",
+            "title": "Pii"
+          },
+          "secrets": {
+            "type": "integer",
+            "title": "Secrets"
+          }
+        },
+        "type": "object",
+        "required": ["malicious_packages", "pii", "secrets"],
+        "title": "AlertSummary",
+        "description": "Represents a set of summary alerts"
       },
       "ChatMessage": {
         "properties": {
@@ -1628,6 +1895,58 @@
         "title": "MuxRule",
         "description": "Represents a mux rule for a provider."
       },
+      "Persona": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          }
+        },
+        "type": "object",
+        "required": ["id", "name", "description"],
+        "title": "Persona",
+        "description": "Represents a persona object."
+      },
+      "PersonaRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          }
+        },
+        "type": "object",
+        "required": ["name", "description"],
+        "title": "PersonaRequest",
+        "description": "Model for creating a new Persona."
+      },
+      "PersonaUpdateRequest": {
+        "properties": {
+          "new_name": {
+            "type": "string",
+            "title": "New Name"
+          },
+          "new_description": {
+            "type": "string",
+            "title": "New Description"
+          }
+        },
+        "type": "object",
+        "required": ["new_name", "new_description"],
+        "title": "PersonaUpdateRequest",
+        "description": "Model for updating a Persona."
+      },
       "ProviderAuthType": {
         "type": "string",
         "enum": ["none", "passthrough", "api_key"],
@@ -1857,27 +2176,6 @@
         "type": "object",
         "required": ["custom_instructions", "muxing_rules"],
         "title": "WorkspaceConfig"
-      },
-      "WorkspaceWithModel": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9_-]+$",
-            "title": "Name"
-          },
-          "provider_model_name": {
-            "type": "string",
-            "title": "Provider Model Name"
-          }
-        },
-        "type": "object",
-        "required": ["id", "name", "provider_model_name"],
-        "title": "WorkspaceWithModel",
-        "description": "Returns a workspace ID with model name"
       }
     }
   }

--- a/src/context/confirm-context.tsx
+++ b/src/context/confirm-context.tsx
@@ -57,8 +57,12 @@ export function ConfirmProvider({ children }: { children: ReactNode }) {
     <ConfirmContext.Provider value={{ confirm }}>
       {children}
 
-      <DialogModalOverlay isDismissable={false} isOpen={isOpen}>
-        <DialogModal>
+      <DialogModalOverlay
+        isDismissable
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+      >
+        <DialogModal isDismissable>
           <Dialog>
             <DialogHeader>
               <DialogTitle>{activeQuestion?.config.title}</DialogTitle>
@@ -70,6 +74,7 @@ export function ConfirmProvider({ children }: { children: ReactNode }) {
                   {activeQuestion?.config.buttons.no ?? '&nbsp;'}
                 </Button>
                 <Button
+                  autoFocus
                   isDestructive={activeQuestion?.config.isDestructive}
                   variant="primary"
                   onPress={() => handleAnswer(true)}

--- a/src/features/providers/components/workspaces-by-provider.tsx
+++ b/src/features/providers/components/workspaces-by-provider.tsx
@@ -1,11 +1,11 @@
-import { V1ListWorkspacesByProviderResponse } from '@/api/generated'
+import { Workspace } from '@/api/generated'
 import { Badge } from '@stacklok/ui-kit'
 import { uniqBy } from 'lodash'
 
 export function WorkspacesByProvider({
   workspaces = [],
 }: {
-  workspaces: V1ListWorkspacesByProviderResponse | undefined
+  workspaces: Workspace[] | undefined
 }) {
   if (workspaces.length === 0) return null
   return (

--- a/src/features/providers/hooks/use-confirm-delete-provider.tsx
+++ b/src/features/providers/hooks/use-confirm-delete-provider.tsx
@@ -8,14 +8,15 @@ export function useConfirmDeleteProvider(
   providerId: string | undefined | null
 ) {
   const { mutateAsync: deleteProvider } = useMutationDeleteProvider()
-  const { data: workspaces } = useQueryWorkspacesByProvider(providerId)
+  const { data: workspacesByProvider } =
+    useQueryWorkspacesByProvider(providerId)
   const { confirm } = useConfirm()
 
   return useCallback(
     async (...params: Parameters<typeof deleteProvider>) => {
       const answer = await confirm(
         <>
-          <WorkspacesByProvider workspaces={workspaces} />
+          <WorkspacesByProvider workspaces={workspacesByProvider?.workspaces} />
           <p>Are you sure you want to permanently delete this provider?</p>
         </>,
         {
@@ -31,6 +32,6 @@ export function useConfirmDeleteProvider(
         return deleteProvider(...params)
       }
     },
-    [confirm, deleteProvider, workspaces]
+    [confirm, deleteProvider, workspacesByProvider]
   )
 }

--- a/src/features/providers/hooks/use-invalidate-providers-queries.ts
+++ b/src/features/providers/hooks/use-invalidate-providers-queries.ts
@@ -1,7 +1,7 @@
 import {
   v1ListAllModelsForAllProvidersQueryKey,
   v1ListProviderEndpointsQueryKey,
-  v1ListWorkspacesByProviderQueryKey,
+  v1ListWorkspacesQueryKey,
 } from '@/api/generated/@tanstack/react-query.gen'
 import { useQueryClient } from '@tanstack/react-query'
 import { useCallback } from 'react'
@@ -14,7 +14,7 @@ export function useInvalidateProvidersQueries() {
     invalidateQueries(queryClient, [
       v1ListProviderEndpointsQueryKey,
       v1ListAllModelsForAllProvidersQueryKey,
-      v1ListWorkspacesByProviderQueryKey,
+      v1ListWorkspacesQueryKey,
     ])
   }, [queryClient])
 

--- a/src/features/providers/hooks/use-query-workspaces-by-provider.ts
+++ b/src/features/providers/hooks/use-query-workspaces-by-provider.ts
@@ -1,4 +1,4 @@
-import { v1ListWorkspacesByProviderOptions } from '@/api/generated/@tanstack/react-query.gen'
+import { v1ListWorkspacesOptions } from '@/api/generated/@tanstack/react-query.gen'
 import { useQuery } from '@tanstack/react-query'
 
 export function useQueryWorkspacesByProvider(
@@ -9,7 +9,7 @@ export function useQueryWorkspacesByProvider(
   }
 
   return useQuery({
-    ...v1ListWorkspacesByProviderOptions({ path: { provider_id: providerId } }),
+    ...v1ListWorkspacesOptions({ query: { provider_id: providerId } }),
     // eslint-disable-next-line no-restricted-syntax
     refetchOnMount: true,
   })

--- a/src/features/workspace/hooks/use-invalidate-workspace-queries.ts
+++ b/src/features/workspace/hooks/use-invalidate-workspace-queries.ts
@@ -1,7 +1,6 @@
 import {
   v1GetWorkspaceMuxesQueryKey,
   v1ListArchivedWorkspacesQueryKey,
-  v1ListWorkspacesByProviderQueryKey,
   v1ListWorkspacesQueryKey,
 } from '@/api/generated/@tanstack/react-query.gen'
 import { invalidateQueries } from '@/lib/react-query-utils'
@@ -16,7 +15,6 @@ export function useInvalidateWorkspaceQueries() {
       v1ListWorkspacesQueryKey,
       v1ListArchivedWorkspacesQueryKey,
       v1GetWorkspaceMuxesQueryKey,
-      v1ListWorkspacesByProviderQueryKey,
     ])
   }, [queryClient])
 


### PR DESCRIPTION
In https://github.com/stacklok/codegate/pull/1233 I made a breaking change — `GET /api/v1/workspaces/:provider_id` was already in use for listing providers in use by a workspace, but now will return a full workspace by name. (`GET /api/v1/workspaces/:provider_id`).

The old functionality can be achieved with `GET /api/v1/workspaces?provider_id={ID}` now instead — this PR wires that up for the frontend.

