### PR TITLE
fix: use package.json overrides to bump `@babel/runtime` & `prismjs` to fix npm audit warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -11366,9 +11366,9 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11868,15 +11868,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/refractor/node_modules/prismjs": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/regenerator-runtime": {

--- a/package.json
+++ b/package.json
@@ -99,6 +99,8 @@
     "vitest-fail-on-console": "^0.7.1"
   },
   "overrides": {
+    "@babel/runtime": "^7.26.10",
+    "prismjs": "^1.30.0",
     "vite": "^6.0.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
```shell
┌────────────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────────────┬─────────────────────────────────────────────────────────────┐
│    Library     │ Vulnerability  │ Severity │ Status │ Installed Version │      Fixed Version      │                            Title                            │
├────────────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────────────┼─────────────────────────────────────────────────────────────┤
│ @babel/runtime │ CVE-2025-27789 │ MEDIUM   │ fixed  │ 7.26.0            │ 7.26.10, 8.0.0-alpha.17 │ Babel is a compiler for writing next generation JavaScript. │
│                │                │          │        │                   │                         │ When using ......                                           │
│                │                │          │        │                   │                         │ https://avd.aquasec.com/nvd/cve-2025-27789                  │
├────────────────┼────────────────┤          │        ├───────────────────┼─────────────────────────┼─────────────────────────────────────────────────────────────┤
│ prismjs        │ CVE-2024-53382 │          │        │ 1.27.0            │ 1.30.0                  │ prismjs: DOM Clobbering vulnerability within the Prism      │
│                │                │          │        │                   │                         │ library's prism-autoloader plugin                           │
│                │                │          │        │                   │                         │ https://avd.aquasec.com/nvd/cve-2024-53382                  │
│                │                │          │        ├───────────────────┤                         │                                                             │
│                │                │          │        │ 1.29.0            │                         │                                                             │
│                │                │          │        │                   │                         │                                                             │
│                │                │          │        │                   │                         │                                                             │
└────────────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────────────┴─────────────────────────────────────────────────────────────┘
```