### PR TITLE
chore: normalize casing on UI titles & labels

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -92,7 +92,7 @@ describe('App', () => {
     )
 
     const workspaceSelectionButton = screen.getByRole('button', {
-      name: 'Active workspace default',
+      name: 'Active workspace: default',
     })
     await waitFor(() => expect(workspaceSelectionButton).toBeVisible())
 

--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -33,7 +33,7 @@ export function ErrorFallbackContent() {
               rel="noopener noreferrer"
               target="_blank"
             >
-              Github issues
+              GitHub issues
               <LinkExternal02 />
             </LinkButton>,
           ]}

--- a/src/constants/empty-state-strings.ts
+++ b/src/constants/empty-state-strings.ts
@@ -15,7 +15,7 @@ export const emptyStateStrings = {
   body: {
     loading: 'Checking for the latest messages.',
     errorDesc:
-      'Please try refreshing the page. If this issue persists, please let us know on Discord, or open a a new Github Issue',
+      'Please try refreshing the page. If this issue persists, please let us know on Discord, or open a a new GitHub issue.',
     getStartedDesc: 'Learn how to get started with CodeGate in your IDE.',
     tryChangingSearch: 'Try changing your search query or clearing the search.',
     messagesWillShowUpWhenWorkspace:
@@ -23,9 +23,9 @@ export const emptyStateStrings = {
     messagesDesc:
       'Messages are issues that CodeGate has detected and mitigated in your interactions with the LLM.',
     secretsDesc:
-      'CodeGate helps you protect sensitive information from being accidentally exposed to AI models and third-party AI provider systems by redacting detected secrets from your prompts using encryption.',
+      'CodeGate helps you protect sensitive information from being accidentally exposed to AI models and third-party AI provider systems by redacting detected secrets from your prompts.',
     piiDesc:
-      'CodeGate helps you protect sensitive personally identifiable information (PII) from being accidentally exposed to AI models and third-party AI provider systems by redacting detected PII from your prompts using encryption.',
+      'CodeGate helps you protect sensitive personally identifiable information (PII) from being accidentally exposed to AI models and third-party AI provider systems by redacting detected PII from your prompts.',
     maliciousDesc:
       "CodeGate's dependency risk insight helps protect your codebase from malicious or vulnerable dependencies. It identifies potentially risky packages and suggests fixed versions or alternative packages to consider.",
   },

--- a/src/features/dashboard-messages/components/__tests__/table-messages.empty-state.test.tsx
+++ b/src/features/dashboard-messages/components/__tests__/table-messages.empty-state.test.tsx
@@ -186,7 +186,7 @@ const TEST_CASES: TestCase[] = [
       actions: [
         {
           role: 'link',
-          name: 'Learn about Workspaces',
+          name: 'Learn about workspaces',
           href: hrefs.external.docs.workspaces,
         },
       ],

--- a/src/features/dashboard-messages/components/section-conversation-secrets.tsx
+++ b/src/features/dashboard-messages/components/section-conversation-secrets.tsx
@@ -27,7 +27,7 @@ export function SectionConversationSecrets({
       <p className="mb-2">
         CodeGate helps you protect sensitive information from being accidentally
         exposed to AI models and third-party AI provider systems by redacting
-        detected secrets from your prompts using encryption.
+        detected secrets from your prompts.
       </p>
       <p className="mb-2">
         The following secrets were detected in plain-text in the input provided

--- a/src/features/dashboard-messages/components/table-messages-empty-state.tsx
+++ b/src/features/dashboard-messages/components/table-messages-empty-state.tsx
@@ -86,7 +86,7 @@ function EmptyStateNoMessagesInWorkspace() {
           target="_blank"
           rel="noopener noreferrer"
         >
-          Learn about Workspaces
+          Learn about workspaces
           <LinkExternal02 />
         </LinkButton>,
       ]}
@@ -151,7 +151,7 @@ export function EmptyStateError() {
           rel="noopener noreferrer"
           target="_blank"
         >
-          Github issues
+          GitHub issues
           <LinkExternal02 />
         </LinkButton>,
       ]}

--- a/src/features/dashboard-messages/lib/get-provider-string.ts
+++ b/src/features/dashboard-messages/lib/get-provider-string.ts
@@ -1,7 +1,7 @@
 export function getProviderString(provider: string | null): string {
   switch (provider) {
     case 'copilot':
-      return 'Github Copilot'
+      return 'GitHub Copilot'
     case null:
       return 'Unknown provider'
     default:

--- a/src/features/header/components/header-active-workspace-selector.tsx
+++ b/src/features/header/components/header-active-workspace-selector.tsx
@@ -56,7 +56,7 @@ export function HeaderActiveWorkspaceSelector() {
   return (
     <DialogTrigger isOpen={isOpen} onOpenChange={(test) => setIsOpen(test)}>
       <Button variant="tertiary" className="flex cursor-pointer">
-        Active workspace{' '}
+        Active workspace:{' '}
         <span className="font-bold">{activeWorkspaceName ?? 'default'}</span>
         <ChevronDown />
       </Button>
@@ -131,7 +131,7 @@ export function HeaderActiveWorkspaceSelector() {
             className="mt-2 flex h-10 justify-start gap-2 pl-2 text-secondary"
           >
             <Settings01 />
-            Manage Workspaces
+            Manage workspaces
           </LinkButton>
         </div>
       </Popover>

--- a/src/features/header/constants/help-menu-items.tsx
+++ b/src/features/header/constants/help-menu-items.tsx
@@ -10,14 +10,14 @@ export const HELP_MENU_ITEMS = [
       {
         icon: <Continue />,
         id: 'continue-setup',
-        href: 'https://docs.codegate.ai/how-to/use-with-continue',
+        href: 'https://docs.codegate.ai/integrations/continue',
         textValue: 'Use with Continue',
         target: '_blank',
       },
       {
         icon: <Copilot />,
         id: 'copilot-setup',
-        href: 'https://docs.codegate.ai/how-to/use-with-copilot',
+        href: 'https://docs.codegate.ai/integrations/copilot',
         textValue: 'Use with Copilot',
         target: '_blank',
       },

--- a/src/features/providers/components/provider-form.tsx
+++ b/src/features/providers/components/provider-form.tsx
@@ -69,7 +69,7 @@ export function ProviderForm({ provider, setProvider }: Props) {
           validationBehavior="aria"
           onChange={(description) => setProvider({ ...provider, description })}
         >
-          <Label>Description (Optional)</Label>
+          <Label>Description (optional)</Label>
           <Input
             placeholder="Provider description"
             value={provider.description}

--- a/src/features/providers/lib/utils.ts
+++ b/src/features/providers/lib/utils.ts
@@ -4,7 +4,7 @@ import { match } from 'ts-pattern'
 export const PROVIDER_AUTH_TYPE_MAP = {
   [ProviderAuthType.NONE]: 'None',
   [ProviderAuthType.PASSTHROUGH]: 'Passthrough',
-  [ProviderAuthType.API_KEY]: 'API Key',
+  [ProviderAuthType.API_KEY]: 'API key',
 }
 
 export function getAuthTypeOptions() {

--- a/src/features/workspace/components/__tests__/workspace-muxing-model.test.tsx
+++ b/src/features/workspace/components/__tests__/workspace-muxing-model.test.tsx
@@ -16,7 +16,7 @@ test('renders muxing model', async () => {
   expect(screen.getByText(/model muxing/i)).toBeVisible()
   expect(
     screen.getByText(
-      /select the model you would like to use in this workspace. This section applies only if you are using the MUX endpoint./i
+      /Select the model\(s\) to use in this workspace. This section applies only if you are using the mux endpoint./i
     )
   ).toBeVisible()
   expect(

--- a/src/features/workspace/components/archive-workspace.tsx
+++ b/src/features/workspace/components/archive-workspace.tsx
@@ -97,7 +97,7 @@ export function ArchiveWorkspace({
     <Card className={twMerge(className, 'shrink-0')}>
       <CardBody className="flex items-center justify-between">
         <div>
-          <Text className="text-primary">Archive Workspace</Text>
+          <Text className="text-primary">Archive workspace</Text>
           <Text className="mb-0 flex items-center text-balance text-secondary">
             Archiving this workspace removes it from the main workspaces list,
             though it can be restored if needed.

--- a/src/features/workspace/components/workspace-muxing-model.tsx
+++ b/src/features/workspace/components/workspace-muxing-model.tsx
@@ -198,7 +198,7 @@ export function WorkspaceMuxingModel({
     return (
       <Card className={twMerge(className, 'shrink-0')}>
         <CardBody className="flex flex-col gap-2">
-          <Text className="text-primary">Model Muxing</Text>
+          <Text className="text-primary">Model muxing</Text>
           <MissingProviderBanner />
         </CardBody>
       </Card>
@@ -214,10 +214,10 @@ export function WorkspaceMuxingModel({
       <Card className={twMerge(className, 'shrink-0')}>
         <CardBody className="flex flex-col gap-6">
           <div className="flex flex-col justify-start">
-            <Text className="text-primary">Model Muxing</Text>
+            <Text className="text-primary">Model muxing</Text>
             <Text className="mb-0 flex items-center gap-1 text-balance text-secondary">
-              Select the model you would like to use in this workspace. This
-              section applies only if you are using the MUX endpoint.
+              Select the model(s) to use in this workspace. This section applies
+              only if you are using the mux endpoint.
               <Link
                 variant="primary"
                 className="flex items-center gap-1 no-underline"
@@ -232,7 +232,7 @@ export function WorkspaceMuxingModel({
           <div className="flex w-full flex-col gap-2">
             <div className="flex gap-2">
               <div className="w-12">&nbsp;</div>
-              <div className="w-2/5">Request Type</div>
+              <div className="w-2/5">Request type</div>
               <div className="w-full">
                 <Label id="filter-by-label-id" className="flex items-center">
                   Filter by
@@ -282,7 +282,7 @@ export function WorkspaceMuxingModel({
               onPress={addRule}
               isDisabled={isArchived}
             >
-              <Plus /> Add Filter
+              <Plus /> Add filter
             </Button>
 
             <LinkButton className="w-fit" variant="tertiary" href="/providers">

--- a/src/routes/route-certificate-security.tsx
+++ b/src/routes/route-certificate-security.tsx
@@ -65,10 +65,10 @@ export function RouteCertificateSecurity() {
     <PageContainer className="max-w-4xl">
       <Breadcrumbs>
         <BreadcrumbHome />
-        <Breadcrumb>Certificate Security</Breadcrumb>
+        <Breadcrumb>Certificate security</Breadcrumb>
       </Breadcrumbs>
 
-      <PageHeading title="Certificate Security" level={1} />
+      <PageHeading title="Certificate security" level={1} />
 
       <Card className="mb-8">
         <CardBody>
@@ -76,7 +76,7 @@ export function RouteCertificateSecurity() {
             <SecurityShieldIcon />
           </div>
           <h2 className="mb-4 text-xl font-semibold">
-            Robust Certificate Security
+            Robust certificate security
           </h2>
           <p className="mb-4 text-secondary">
             Security is a top priority for us. We have designed CodeGate's local

--- a/src/routes/route-provider-create.tsx
+++ b/src/routes/route-provider-create.tsx
@@ -38,7 +38,7 @@ export function RouteProviderCreate() {
   }
 
   return (
-    <ProviderDialog title="Add Provider">
+    <ProviderDialog title="Add provider">
       <Form
         onSubmit={handleSubmit}
         validationBehavior="aria"

--- a/src/routes/route-provider-update.tsx
+++ b/src/routes/route-provider-update.tsx
@@ -23,7 +23,7 @@ export function RouteProviderUpdate() {
   if (provider === undefined) return
 
   return (
-    <ProviderDialog title="Manage Provider">
+    <ProviderDialog title="Manage provider">
       <Form
         onSubmit={handleSubmit}
         validationBehavior="aria"

--- a/src/routes/route-providers.tsx
+++ b/src/routes/route-providers.tsx
@@ -22,7 +22,7 @@ export function RouteProvider({ className }: { className?: string }) {
       </Breadcrumbs>
       <PageHeading level={4} title="Providers">
         <LinkButton className="w-fit" href="/providers/new">
-          <PlusSquare /> Add Provider
+          <PlusSquare /> Add provider
         </LinkButton>
       </PageHeading>
       <Card className={twMerge(className, 'shrink-0')}>

--- a/src/routes/route-workspace-creation.tsx
+++ b/src/routes/route-workspace-creation.tsx
@@ -9,11 +9,11 @@ export function RouteWorkspaceCreation() {
     <PageContainer>
       <Breadcrumbs>
         <BreadcrumbHome />
-        <Breadcrumb href="/workspaces">Manage Workspaces</Breadcrumb>
-        <Breadcrumb>Create Workspace</Breadcrumb>
+        <Breadcrumb href="/workspaces">Manage workspaces</Breadcrumb>
+        <Breadcrumb>Create workspace</Breadcrumb>
       </Breadcrumbs>
 
-      <PageHeading level={1} title="Create Workspace" />
+      <PageHeading level={1} title="Create workspace" />
       <WorkspaceCreation />
     </PageContainer>
   )

--- a/src/routes/route-workspace.tsx
+++ b/src/routes/route-workspace.tsx
@@ -42,8 +42,8 @@ export function RouteWorkspace() {
     <PageContainer>
       <Breadcrumbs>
         <BreadcrumbHome />
-        <Breadcrumb href="/workspaces">Manage Workspaces</Breadcrumb>
-        <Breadcrumb>Workspace Settings</Breadcrumb>
+        <Breadcrumb href="/workspaces">Manage workspaces</Breadcrumb>
+        <Breadcrumb>Workspace settings</Breadcrumb>
       </Breadcrumbs>
 
       <PageHeading level={1} title={`Workspace settings for ${name}`}>

--- a/src/routes/route-workspaces.tsx
+++ b/src/routes/route-workspaces.tsx
@@ -25,10 +25,10 @@ export function RouteWorkspaces() {
     <PageContainer>
       <Breadcrumbs>
         <BreadcrumbHome />
-        <Breadcrumb>Manage Workspaces</Breadcrumb>
+        <Breadcrumb>Manage workspaces</Breadcrumb>
       </Breadcrumbs>
 
-      <PageHeading level={1} title="Manage Workspaces">
+      <PageHeading level={1} title="Manage workspaces">
         <div className="flex gap-2">
           <WorkspaceUploadButton />
           <TooltipTrigger delay={0}>


### PR DESCRIPTION
We have some inconsistent capitalizing of headings and labels in the UI. After speaking with @jtenniswood, seems we don't have a well-established standard, so this PR leans to sentence case.

Also removed mentions of encryption in the secrets redaction strings.

All these changes should be purely cosmetic.